### PR TITLE
draft: Add timeline components and badge links

### DIFF
--- a/nativephp.json
+++ b/nativephp.json
@@ -345,6 +345,22 @@
             "self_closing": true
         },
         {
+            "type": "timeline",
+            "element": "Nativephp\\NativeUi\\Elements\\Timeline",
+            "blade": "Nativephp\\NativeUi\\Components\\Timeline",
+            "android_renderer": "com.nativephp.plugins.native_ui.ui.TimelineRenderer",
+            "ios_renderer": "NativeUITimelineRenderer",
+            "self_closing": false
+        },
+        {
+            "type": "timeline_block",
+            "element": "Nativephp\\NativeUi\\Elements\\TimelineBlock",
+            "blade": "Nativephp\\NativeUi\\Components\\TimelineBlock",
+            "android_renderer": "com.nativephp.plugins.native_ui.ui.TimelineBlockRenderer",
+            "ios_renderer": "NativeUITimelineBlockRenderer",
+            "self_closing": false
+        },
+        {
             "type": "card",
             "element": "Nativephp\\NativeUi\\Elements\\Card",
             "blade": "Nativephp\\NativeUi\\Components\\Card",

--- a/resources/android/BadgeRenderer.kt
+++ b/resources/android/BadgeRenderer.kt
@@ -1,6 +1,9 @@
 package com.nativephp.plugins.native_ui.ui
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.defaultMinSize
@@ -12,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -31,6 +35,8 @@ object BadgeRenderer {
         val label   = p.getString("label")
         val variant = p.getString("variant", "destructive")
         val a11yLabel = p.getString("a11y_label")
+        val link = p.getString("link")
+        val context = LocalContext.current
 
         val theme = if (isSystemInDarkTheme()) NativeUITheme.dark else NativeUITheme.light
 
@@ -48,6 +54,18 @@ object BadgeRenderer {
             .defaultMinSize(minWidth = 20.dp, minHeight = 20.dp)
             .clip(RoundedCornerShape(10.dp))
             .background(bg)
+            .let { m ->
+                if (link.isNotEmpty()) {
+                    m.clickable {
+                        runCatching {
+                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))
+                            context.startActivity(intent)
+                        }
+                    }
+                } else {
+                    m
+                }
+            }
             .padding(horizontal = 6.dp, vertical = 2.dp)
             .let { m -> if (a11yLabel.isNotEmpty()) m.semantics { contentDescription = a11yLabel } else m }
 

--- a/resources/android/TimelineRenderer.kt
+++ b/resources/android/TimelineRenderer.kt
@@ -1,0 +1,145 @@
+package com.nativephp.plugins.native_ui.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.nativephp.mobile.ui.MaterialIcon
+import com.nativephp.mobile.ui.nativerender.NativeUINode
+import com.nativephp.mobile.ui.nativerender.NodeView
+
+object TimelineRenderer {
+    @Composable
+    fun Render(node: NativeUINode, modifier: Modifier) {
+        val horizontal = node.props.getString("orientation", "vertical") == "horizontal"
+
+        if (horizontal) {
+            Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(18.dp)) {
+                node.children.forEachIndexed { index, child ->
+                    timelineChild(child, index == node.children.lastIndex, true)
+                }
+            }
+        } else {
+            Column(modifier = modifier) {
+                node.children.forEachIndexed { index, child ->
+                    timelineChild(child, index == node.children.lastIndex, false)
+                }
+            }
+        }
+    }
+}
+
+object TimelineBlockRenderer {
+    @Composable
+    fun Render(node: NativeUINode, modifier: Modifier) {
+        Box(modifier = modifier) {
+            TimelineBlockBody(node = node, isLast = true, horizontal = false)
+        }
+    }
+}
+
+@Composable
+private fun timelineChild(node: NativeUINode, isLast: Boolean, horizontal: Boolean) {
+    if (node.type == "timeline_block") {
+        TimelineBlockBody(node = node, isLast = isLast, horizontal = horizontal)
+    } else {
+        NodeView(node = node)
+    }
+}
+
+@Composable
+private fun TimelineBlockBody(node: NativeUINode, isLast: Boolean, horizontal: Boolean) {
+    if (horizontal) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TimelineMarker(node)
+                if (!isLast) {
+                    Spacer(Modifier.width(64.dp).height(2.dp).background(Color(0xFFE5E7EB)))
+                }
+            }
+            TimelineContent(node)
+        }
+    } else {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                TimelineMarker(node)
+                if (!isLast) {
+                    Spacer(Modifier.width(2.dp).defaultMinSize(minHeight = 72.dp).background(Color(0xFFE5E7EB)))
+                }
+            }
+            TimelineContent(
+                node = node,
+                modifier = Modifier.weight(1f).padding(bottom = if (isLast) 0.dp else 24.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TimelineMarker(node: NativeUINode) {
+    val icon = node.props.getString("icon", "circle.fill")
+
+    Box(
+        modifier = Modifier
+            .size(28.dp)
+            .background(Color(0xFFF1F5F9), CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        MaterialIcon(
+            name = icon,
+            contentDescription = icon,
+            size = if (icon == "circle.fill") 9.dp else 15.dp,
+            tint = Color(0xFF64748B),
+        )
+    }
+}
+
+@Composable
+private fun TimelineContent(node: NativeUINode, modifier: Modifier = Modifier) {
+    val heading = node.props.getString("heading")
+    val status = node.props.getString("status")
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        if (heading.isNotEmpty() || status.isNotEmpty()) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (heading.isNotEmpty()) {
+                    Text(
+                        text = heading,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                }
+                if (status.isNotEmpty()) {
+                    Text(
+                        text = status,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                    )
+                }
+            }
+        }
+
+        node.children.forEach { child ->
+            NodeView(node = child)
+        }
+    }
+}

--- a/resources/ios/NativeUIBadgeRenderer.swift
+++ b/resources/ios/NativeUIBadgeRenderer.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// SwiftUI Badge — capsule pill with count or short label.
 ///
@@ -25,6 +26,7 @@ struct NativeUIBadgeRenderer: View {
         let label     = p.getString("label")
         let variant   = p.getString("variant", default: "destructive")
         let a11yLabel = p.getString("a11y_label")
+        let link      = p.getString("link")
 
         let glassFlags = p.getInt("glass", default: 0)
         let glassEnabled     = (glassFlags & 1) != 0
@@ -44,7 +46,7 @@ struct NativeUIBadgeRenderer: View {
             }
         }()
 
-        Text(text)
+        let badge = Text(text)
             .font(.system(size: 12, weight: .bold))
             .foregroundColor(fg)
             .padding(.horizontal, 6)
@@ -57,6 +59,25 @@ struct NativeUIBadgeRenderer: View {
                 hasUserBg: hasUserBg
             ))
             .modifier(A11yLabelModifier(label: a11yLabel))
+
+        if link.isEmpty {
+            badge
+        } else {
+            Button {
+                openBadgeLink(link)
+            } label: {
+                badge
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func openBadgeLink(_ link: String) {
+        guard let url = URL(string: link) else {
+            return
+        }
+
+        UIApplication.shared.open(url)
     }
 }
 

--- a/resources/ios/NativeUITimelineRenderer.swift
+++ b/resources/ios/NativeUITimelineRenderer.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct NativeUITimelineRenderer: View {
+    let node: NativeUINode
+
+    private var isHorizontal: Bool {
+        node.props.getString("orientation", default: "vertical") == "horizontal"
+    }
+
+    var body: some View {
+        if isHorizontal {
+            HStack(alignment: .top, spacing: 18) {
+                ForEach(Array(node.children.enumerated()), id: \.element.id) { index, child in
+                    timelineChild(child, isLast: index == node.children.count - 1, horizontal: true)
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(node.children.enumerated()), id: \.element.id) { index, child in
+                    timelineChild(child, isLast: index == node.children.count - 1, horizontal: false)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func timelineChild(_ child: NativeUINode, isLast: Bool, horizontal: Bool) -> some View {
+        if child.type == "timeline_block" {
+            TimelineBlockBody(node: child, isLast: isLast, horizontal: horizontal)
+        } else {
+            NodeView(node: child).equatable()
+        }
+    }
+}
+
+struct NativeUITimelineBlockRenderer: View {
+    let node: NativeUINode
+
+    var body: some View {
+        TimelineBlockBody(node: node, isLast: true, horizontal: false)
+    }
+}
+
+private struct TimelineBlockBody: View {
+    let node: NativeUINode
+    let isLast: Bool
+    let horizontal: Bool
+
+    private var heading: String { node.props.getString("heading") }
+    private var status: String { node.props.getString("status") }
+    private var icon: String { node.props.getString("icon", default: "circle.fill") }
+
+    var body: some View {
+        if horizontal {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .center, spacing: 8) {
+                    marker
+                    if !isLast {
+                        Rectangle()
+                            .fill(Color(argb: 0xFFE5E7EB))
+                            .frame(width: 64, height: 2)
+                    }
+                }
+                content
+            }
+        } else {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(spacing: 8) {
+                    marker
+                    if !isLast {
+                        Rectangle()
+                            .fill(Color(argb: 0xFFE5E7EB))
+                            .frame(width: 2, height: 72)
+                    }
+                }
+                .frame(width: 30)
+
+                content
+                    .padding(.bottom, isLast ? 0 : 24)
+            }
+        }
+    }
+
+    private var marker: some View {
+        ZStack {
+            Circle()
+                .fill(Color(argb: 0xFFF1F5F9))
+                .frame(width: 28, height: 28)
+            Image(systemName: getIconForName(icon))
+                .font(.system(size: icon == "circle.fill" ? 9 : 15, weight: .semibold))
+                .foregroundColor(Color(argb: 0xFF64748B))
+        }
+    }
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if !heading.isEmpty || !status.isEmpty {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    if !heading.isEmpty {
+                        Text(heading)
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(Color.primary)
+                    }
+                    if !status.isEmpty {
+                        Text(status)
+                            .font(.system(size: 12))
+                            .foregroundColor(Color.secondary)
+                    }
+                }
+            }
+
+            ForEach(node.children) { child in
+                NodeView(node: child).equatable()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/src/Components/Timeline.php
+++ b/src/Components/Timeline.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Nativephp\NativeUi\Components;
+
+use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
+
+class Timeline extends NativeBladeComponent
+{
+    protected function elementType(): string
+    {
+        return 'timeline';
+    }
+}

--- a/src/Components/TimelineBlock.php
+++ b/src/Components/TimelineBlock.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Nativephp\NativeUi\Components;
+
+use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
+
+class TimelineBlock extends NativeBladeComponent
+{
+    protected function elementType(): string
+    {
+        return 'timeline_block';
+    }
+}

--- a/src/Elements/Badge.php
+++ b/src/Elements/Badge.php
@@ -15,7 +15,8 @@ use Native\Mobile\Edge\Element;
  *   accent                — theme.accent / on-accent
  *
  * Use either `count` (renders an integer; "99+" for >99) or `label` (arbitrary
- * short text). If both set, `label` wins.
+ * short text). If both set, `label` wins. `link` / `url` makes the badge open
+ * the URL with the platform browser when pressed.
  */
 class Badge extends Element
 {
@@ -39,6 +40,9 @@ class Badge extends Element
         if (isset($attrs['count']))   { $this->count((int) $attrs['count']); }
         if (isset($attrs['label']))   { $this->label($attrs['label']); }
         if (isset($attrs['variant'])) { $this->variant((string) $attrs['variant']); }
+        if (isset($attrs['link']) || isset($attrs['url'])) {
+            $this->link((string) ($attrs['link'] ?? $attrs['url']));
+        }
 
         if (isset($attrs['a11y-label']) || isset($attrs['a11yLabel'])) {
             $this->a11yLabel($attrs['a11y-label'] ?? $attrs['a11yLabel']);
@@ -62,6 +66,13 @@ class Badge extends Element
     public function variant(string $variant): static
     {
         $this->badgeProps['variant'] = $variant;
+
+        return $this;
+    }
+
+    public function link(string $url): static
+    {
+        $this->badgeProps['link'] = $url;
 
         return $this;
     }

--- a/src/Elements/Timeline.php
+++ b/src/Elements/Timeline.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Nativephp\NativeUi\Elements;
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+
+class Timeline extends Element
+{
+    protected string $type = 'timeline';
+
+    /** @var array<string, mixed> */
+    protected array $timelineProps = [];
+
+    public function applyAttributes(array $attrs): void
+    {
+        if (isset($attrs['orientation'])) {
+            $this->orientation((string) $attrs['orientation']);
+        }
+
+        if (isset($attrs['horizontal']) && filter_var($attrs['horizontal'], FILTER_VALIDATE_BOOL)) {
+            $this->orientation('horizontal');
+        }
+
+        if (isset($attrs['vertical']) && filter_var($attrs['vertical'], FILTER_VALIDATE_BOOL)) {
+            $this->orientation('vertical');
+        }
+    }
+
+    public function orientation(string $value): static
+    {
+        $this->timelineProps['orientation'] = $value;
+
+        return $this;
+    }
+
+    protected function resolveProps(CallbackRegistry $registry): array
+    {
+        return $this->timelineProps;
+    }
+}

--- a/src/Elements/TimelineBlock.php
+++ b/src/Elements/TimelineBlock.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Nativephp\NativeUi\Elements;
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+
+class TimelineBlock extends Element
+{
+    protected string $type = 'timeline_block';
+
+    /** @var array<string, mixed> */
+    protected array $blockProps = [];
+
+    public function applyAttributes(array $attrs): void
+    {
+        if (isset($attrs['heading'])) {
+            $this->heading((string) $attrs['heading']);
+        }
+
+        if (isset($attrs['icon'])) {
+            $this->icon((string) $attrs['icon']);
+        }
+
+        if (isset($attrs['status'])) {
+            $this->status((string) $attrs['status']);
+        }
+    }
+
+    public function heading(string $value): static
+    {
+        $this->blockProps['heading'] = $value;
+
+        return $this;
+    }
+
+    public function icon(string $value): static
+    {
+        $this->blockProps['icon'] = $value;
+
+        return $this;
+    }
+
+    public function status(string $value): static
+    {
+        $this->blockProps['status'] = $value;
+
+        return $this;
+    }
+
+    protected function resolveProps(CallbackRegistry $registry): array
+    {
+        return $this->blockProps;
+    }
+}


### PR DESCRIPTION
Adds native timeline/timeline-block components for iOS and Android, plus link/url support for badges so badge taps can open external URLs.\n\nIncludes:\n- PHP elements and Blade components for native:timeline and native:timeline-block\n- SwiftUI renderers for vertical/horizontal timelines and linked badges\n- Kotlin/Compose renderers for vertical/horizontal timelines and linked badges\n- nativephp.json component registrations\n\nValidation:\n- git diff --check\n- php -l on changed PHP files\n- nativephp.json decoded with JSON_THROW_ON_ERROR