### PR TITLE
refactor(mobile-ui)!: rename package to nativephp/mobile-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ A NativePHP Mobile plugin
 ## Installation
 
 ```bash
-composer require nativephp/native-ui
+composer require nativephp/mobile-ui
 ```
 
 ## Usage
 
 ```php
-use Nativephp\NativeUi\Facades\NativeUI;
+use Native\Mobile\UI\Facades\NativeUI;
 
 // Execute functionality
 $result = NativeUI::execute(['option1' => 'value']);
@@ -25,7 +25,7 @@ $status = NativeUI::getStatus();
 ```php
 use Livewire\Attributes\On;
 
-#[On('native:Nativephp\NativeUi\Events\NativeUICompleted')]
+#[On('native:Native\Mobile\UI\Events\NativeUICompleted')]
 public function handleNativeUICompleted($result, $id = null)
 {
     // Handle the event
@@ -76,7 +76,7 @@ content description on Android.
 ```
 
 ```php
-use Nativephp\NativeUi\Elements\Button;
+use Native\Mobile\UI\Elements\Button;
 
 Button::make()
     ->icon('plus')

--- a/SHIPPING-CHECKLIST.md
+++ b/SHIPPING-CHECKLIST.md
@@ -1,6 +1,6 @@
 # NativeUI — Shipping Checklist
 
-Audit list for taking nativephp/native-ui from unreleased to ship-ready. Verified on iOS **and** Android in `~/Herd/native`. Docs are kept in sync as we go at `~/Herd/nativephp/resources/views/docs/mobile/3/edge-components/`.
+Audit list for taking nativephp/mobile-ui from unreleased to ship-ready. Verified on iOS **and** Android in `~/Herd/native`. Docs are kept in sync as we go at `~/Herd/nativephp/resources/views/docs/mobile/3/edge-components/`.
 
 **Phasing**: Layout first → Buttons & pressables → Inputs → Feedback → Lists → Overlays → Tabs → Misc. Cross-cutting items (§0) get checked as they come up; not gated to a phase.
 

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,17 @@
 {
     "name": "nativephp/mobile-ui",
-    "description": "A NativePHP Mobile plugin",
-    "type": "nativephp-ui-plugin",
+    "description": "Native SwiftUI and Jetpack Composer components for NativePHP",
+    "type": "nativephp-plugin",
     "license": "MIT",
     "authors": [
         {
-            "name": "Your Name",
-            "email": "you@example.com"
+            "name": "NativePHP",
+            "email": "support@nativephp.com"
         }
     ],
     "require": {
         "php": "^8.2",
-        "nativephp/mobile": "*"
+        "nativephp/mobile": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -38,5 +38,11 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true
         }
-    }
+    },
+    "funding": [
+        {
+            "type": "other",
+            "url": "https://nativephp.com/sponsor"
+        }
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nativephp/native-ui",
+    "name": "nativephp/mobile-ui",
     "description": "A NativePHP Mobile plugin",
     "type": "nativephp-ui-plugin",
     "license": "MIT",
@@ -15,13 +15,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Nativephp\\NativeUi\\": "src/"
+            "Native\\Mobile\\UI\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "Nativephp\\NativeUi\\NativeUIServiceProvider"
+                "Native\\Mobile\\UI\\NativeUIServiceProvider"
             ]
         },
         "nativephp": {

--- a/config/native-ui.php
+++ b/config/native-ui.php
@@ -6,7 +6,7 @@
  * Published via `php artisan vendor:publish --tag=native-ui-config`.
  * Edit to customize your app's visual identity in one place.
  *
- * For dynamic per-tenant theming, use Nativephp\NativeUi\Theme::merge([...])
+ * For dynamic per-tenant theming, use Native\Mobile\UI\Theme::merge([...])
  * from a service provider. Runtime merges deep-merge on top of these values.
  *
  * Decision log: /docs/NATIVE-UI-REWRITE-PLAN.md (D — theme layer)

--- a/nativephp.json
+++ b/nativephp.json
@@ -1,5 +1,5 @@
 {
-    "name": "nativephp/native-ui",
+    "name": "nativephp/mobile-ui",
     "version": "1.0.0",
     "description": "Material3 Compose UI components for NativePHP Mobile",
     "namespace": "NativeUI",
@@ -210,48 +210,48 @@
         },
         {
             "type": "list",
-            "element": "Nativephp\\NativeUi\\Elements\\NativeList",
-            "blade": "Nativephp\\NativeUi\\Components\\NativeList",
+            "element": "Native\\Mobile\\UI\\Elements\\NativeList",
+            "blade": "Native\\Mobile\\UI\\Components\\NativeList",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ListRenderer",
             "ios_renderer": "NativeUIListRenderer",
             "self_closing": false
         },
         {
             "type": "virtual_list",
-            "element": "Nativephp\\NativeUi\\Elements\\NativeVirtualList",
-            "blade": "Nativephp\\NativeUi\\Components\\NativeVirtualList",
+            "element": "Native\\Mobile\\UI\\Elements\\NativeVirtualList",
+            "blade": "Native\\Mobile\\UI\\Components\\NativeVirtualList",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.VirtualListRenderer",
             "ios_renderer": "NativeUIVirtualListRenderer",
             "self_closing": true
         },
         {
             "type": "modal",
-            "element": "Nativephp\\NativeUi\\Elements\\Modal",
-            "blade": "Nativephp\\NativeUi\\Components\\Modal",
+            "element": "Native\\Mobile\\UI\\Elements\\Modal",
+            "blade": "Native\\Mobile\\UI\\Components\\Modal",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ModalRenderer",
             "ios_renderer": "NativeUIModalRenderer",
             "self_closing": false
         },
         {
             "type": "button",
-            "element": "Nativephp\\NativeUi\\Elements\\Button",
-            "blade": "Nativephp\\NativeUi\\Components\\Button",
+            "element": "Native\\Mobile\\UI\\Elements\\Button",
+            "blade": "Native\\Mobile\\UI\\Components\\Button",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ButtonRenderer",
             "ios_renderer": "NativeUIButtonRenderer",
             "self_closing": true
         },
         {
             "type": "progress_bar",
-            "element": "Nativephp\\NativeUi\\Elements\\ProgressBar",
-            "blade": "Nativephp\\NativeUi\\Components\\ProgressBar",
+            "element": "Native\\Mobile\\UI\\Elements\\ProgressBar",
+            "blade": "Native\\Mobile\\UI\\Components\\ProgressBar",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ProgressBarRenderer",
             "ios_renderer": "NativeUIProgressBarRenderer",
             "self_closing": true
         },
         {
             "type": "activity_indicator",
-            "element": "Nativephp\\NativeUi\\Elements\\ActivityIndicator",
-            "blade": "Nativephp\\NativeUi\\Components\\ActivityIndicator",
+            "element": "Native\\Mobile\\UI\\Elements\\ActivityIndicator",
+            "blade": "Native\\Mobile\\UI\\Components\\ActivityIndicator",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ActivityIndicatorRenderer",
             "ios_renderer": "NativeUIActivityIndicatorRenderer",
             "self_closing": true
@@ -259,175 +259,175 @@
         {
             "type": "icon",
             "element": "Native\\Mobile\\Edge\\Elements\\Icon",
-            "blade": "Nativephp\\NativeUi\\Components\\Icon",
+            "blade": "Native\\Mobile\\UI\\Components\\Icon",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.IconRenderer",
             "ios_renderer": "NativeUIIconRenderer",
             "self_closing": true
         },
         {
             "type": "outlined_text_input",
-            "element": "Nativephp\\NativeUi\\Elements\\OutlinedTextInput",
-            "blade": "Nativephp\\NativeUi\\Components\\OutlinedTextInput",
+            "element": "Native\\Mobile\\UI\\Elements\\OutlinedTextInput",
+            "blade": "Native\\Mobile\\UI\\Components\\OutlinedTextInput",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.OutlinedTextInputRenderer",
             "ios_renderer": "NativeUIOutlinedTextInputRenderer",
             "self_closing": true
         },
         {
             "type": "bare_text_input",
-            "element": "Nativephp\\NativeUi\\Elements\\BareTextInput",
-            "blade": "Nativephp\\NativeUi\\Components\\BareTextInput",
+            "element": "Native\\Mobile\\UI\\Elements\\BareTextInput",
+            "blade": "Native\\Mobile\\UI\\Components\\BareTextInput",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.BareTextInputRenderer",
             "ios_renderer": "NativeUIBareTextInputRenderer",
             "self_closing": true
         },
         {
             "type": "filled_text_input",
-            "element": "Nativephp\\NativeUi\\Elements\\FilledTextInput",
-            "blade": "Nativephp\\NativeUi\\Components\\FilledTextInput",
+            "element": "Native\\Mobile\\UI\\Elements\\FilledTextInput",
+            "blade": "Native\\Mobile\\UI\\Components\\FilledTextInput",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.FilledTextInputRenderer",
             "ios_renderer": "NativeUIFilledTextInputRenderer",
             "self_closing": true
         },
         {
             "type": "toggle",
-            "element": "Nativephp\\NativeUi\\Elements\\Toggle",
-            "blade": "Nativephp\\NativeUi\\Components\\Toggle",
+            "element": "Native\\Mobile\\UI\\Elements\\Toggle",
+            "blade": "Native\\Mobile\\UI\\Components\\Toggle",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ToggleRenderer",
             "ios_renderer": "NativeUIToggleRenderer",
             "self_closing": true
         },
         {
             "type": "checkbox",
-            "element": "Nativephp\\NativeUi\\Elements\\Checkbox",
-            "blade": "Nativephp\\NativeUi\\Components\\Checkbox",
+            "element": "Native\\Mobile\\UI\\Elements\\Checkbox",
+            "blade": "Native\\Mobile\\UI\\Components\\Checkbox",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.CheckboxRenderer",
             "ios_renderer": "NativeUICheckboxRenderer",
             "self_closing": true
         },
         {
             "type": "slider",
-            "element": "Nativephp\\NativeUi\\Elements\\Slider",
-            "blade": "Nativephp\\NativeUi\\Components\\Slider",
+            "element": "Native\\Mobile\\UI\\Elements\\Slider",
+            "blade": "Native\\Mobile\\UI\\Components\\Slider",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.SliderRenderer",
             "ios_renderer": "NativeUISliderRenderer",
             "self_closing": true
         },
         {
             "type": "select",
-            "element": "Nativephp\\NativeUi\\Elements\\Select",
-            "blade": "Nativephp\\NativeUi\\Components\\Select",
+            "element": "Native\\Mobile\\UI\\Elements\\Select",
+            "blade": "Native\\Mobile\\UI\\Components\\Select",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.SelectRenderer",
             "ios_renderer": "NativeUISelectRenderer",
             "self_closing": true
         },
         {
             "type": "radio_group",
-            "element": "Nativephp\\NativeUi\\Elements\\RadioGroup",
-            "blade": "Nativephp\\NativeUi\\Components\\RadioGroup",
+            "element": "Native\\Mobile\\UI\\Elements\\RadioGroup",
+            "blade": "Native\\Mobile\\UI\\Components\\RadioGroup",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.RadioGroupRenderer",
             "ios_renderer": "NativeUIRadioGroupRenderer",
             "self_closing": false
         },
         {
             "type": "radio",
-            "element": "Nativephp\\NativeUi\\Elements\\Radio",
-            "blade": "Nativephp\\NativeUi\\Components\\Radio",
+            "element": "Native\\Mobile\\UI\\Elements\\Radio",
+            "blade": "Native\\Mobile\\UI\\Components\\Radio",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.RadioRenderer",
             "ios_renderer": "NativeUIEmptyRenderer",
             "self_closing": true
         },
         {
             "type": "badge",
-            "element": "Nativephp\\NativeUi\\Elements\\Badge",
-            "blade": "Nativephp\\NativeUi\\Components\\Badge",
+            "element": "Native\\Mobile\\UI\\Elements\\Badge",
+            "blade": "Native\\Mobile\\UI\\Components\\Badge",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.BadgeRenderer",
             "ios_renderer": "NativeUIBadgeRenderer",
             "self_closing": true
         },
         {
             "type": "chip",
-            "element": "Nativephp\\NativeUi\\Elements\\Chip",
-            "blade": "Nativephp\\NativeUi\\Components\\Chip",
+            "element": "Native\\Mobile\\UI\\Elements\\Chip",
+            "blade": "Native\\Mobile\\UI\\Components\\Chip",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ChipRenderer",
             "ios_renderer": "NativeUIChipRenderer",
             "self_closing": true
         },
         {
             "type": "list_item",
-            "element": "Nativephp\\NativeUi\\Elements\\ListItem",
-            "blade": "Nativephp\\NativeUi\\Components\\ListItem",
+            "element": "Native\\Mobile\\UI\\Elements\\ListItem",
+            "blade": "Native\\Mobile\\UI\\Components\\ListItem",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ListItemRenderer",
             "ios_renderer": "NativeUIListItemRenderer",
             "self_closing": true
         },
         {
             "type": "list_section",
-            "element": "Nativephp\\NativeUi\\Elements\\ListSection",
-            "blade": "Nativephp\\NativeUi\\Components\\ListSection",
+            "element": "Native\\Mobile\\UI\\Elements\\ListSection",
+            "blade": "Native\\Mobile\\UI\\Components\\ListSection",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
             "ios_renderer": "NativeUIEmptyRenderer",
             "self_closing": false
         },
         {
             "type": "tab_row",
-            "element": "Nativephp\\NativeUi\\Elements\\TabRow",
-            "blade": "Nativephp\\NativeUi\\Components\\TabRow",
+            "element": "Native\\Mobile\\UI\\Elements\\TabRow",
+            "blade": "Native\\Mobile\\UI\\Components\\TabRow",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.TabRowRenderer",
             "ios_renderer": "NativeUITabRowRenderer",
             "self_closing": false
         },
         {
             "type": "tab",
-            "element": "Nativephp\\NativeUi\\Elements\\Tab",
-            "blade": "Nativephp\\NativeUi\\Components\\Tab",
+            "element": "Native\\Mobile\\UI\\Elements\\Tab",
+            "blade": "Native\\Mobile\\UI\\Components\\Tab",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.TabRenderer",
             "ios_renderer": "NativeUIEmptyRenderer",
             "self_closing": true
         },
         {
             "type": "bottom_sheet",
-            "element": "Nativephp\\NativeUi\\Elements\\BottomSheet",
-            "blade": "Nativephp\\NativeUi\\Components\\BottomSheet",
+            "element": "Native\\Mobile\\UI\\Elements\\BottomSheet",
+            "blade": "Native\\Mobile\\UI\\Components\\BottomSheet",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.BottomSheetRenderer",
             "ios_renderer": "NativeUIBottomSheetRenderer",
             "self_closing": false
         },
         {
             "type": "button_group",
-            "element": "Nativephp\\NativeUi\\Elements\\ButtonGroup",
-            "blade": "Nativephp\\NativeUi\\Components\\ButtonGroup",
+            "element": "Native\\Mobile\\UI\\Elements\\ButtonGroup",
+            "blade": "Native\\Mobile\\UI\\Components\\ButtonGroup",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.ButtonGroupRenderer",
             "ios_renderer": "NativeUIButtonGroupRenderer",
             "self_closing": true
         },
         {
             "type": "carousel",
-            "element": "Nativephp\\NativeUi\\Elements\\Carousel",
-            "blade": "Nativephp\\NativeUi\\Components\\Carousel",
+            "element": "Native\\Mobile\\UI\\Elements\\Carousel",
+            "blade": "Native\\Mobile\\UI\\Components\\Carousel",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.CarouselRenderer",
             "ios_renderer": "NativeUICarouselRenderer",
             "self_closing": false
         },
         {
             "type": "native_drawer",
-            "element": "Nativephp\\NativeUi\\Elements\\NativeDrawer",
-            "blade": "Nativephp\\NativeUi\\Components\\NativeDrawer",
+            "element": "Native\\Mobile\\UI\\Elements\\NativeDrawer",
+            "blade": "Native\\Mobile\\UI\\Components\\NativeDrawer",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
             "ios_renderer": "NativeUIEmptyRenderer",
             "self_closing": false
         },
         {
             "type": "floating_overlay",
-            "element": "Nativephp\\NativeUi\\Elements\\FloatingOverlay",
-            "blade": "Nativephp\\NativeUi\\Components\\FloatingOverlay",
+            "element": "Native\\Mobile\\UI\\Elements\\FloatingOverlay",
+            "blade": "Native\\Mobile\\UI\\Components\\FloatingOverlay",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
             "ios_renderer": "NativeUIEmptyRenderer",
             "self_closing": false
         },
         {
             "type": "webview",
-            "element": "Nativephp\\NativeUi\\Elements\\Webview",
-            "blade": "Nativephp\\NativeUi\\Components\\Webview",
+            "element": "Native\\Mobile\\UI\\Elements\\Webview",
+            "blade": "Native\\Mobile\\UI\\Components\\Webview",
             "android_renderer": "com.nativephp.plugins.native_ui.ui.WebviewRenderer",
             "ios_renderer": "NativeUIWebviewRenderer",
             "self_closing": true

--- a/resources/android/NativeUITheme.kt
+++ b/resources/android/NativeUITheme.kt
@@ -19,7 +19,7 @@ import org.json.JSONObject
  * One coherent set of theme tokens (light OR dark). Renderers read the
  * active tokens via [LocalNativeUITheme].
  *
- * The PHP side (`Nativephp\NativeUi\Theme::merge([...])`) is the source of
+ * The PHP side (`Native\Mobile\UI\Theme::merge([...])`) is the source of
  * truth; tokens arrive over the bridge via `NativeUI.Theme.Set`.
  */
 data class NativeUITokens(

--- a/resources/android/VirtualListRenderer.kt
+++ b/resources/android/VirtualListRenderer.kt
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
  * The callback fires with `[from, to]` (overscan applied) as
  * `"$from,$to"` text — PHP decodes via the `virtual_window` callback kind.
  *
- * See `Plugins/nativephp/native-ui/src/Elements/NativeVirtualList.php` for
+ * See `Plugins/nativephp/mobile-ui/src/Elements/NativeVirtualList.php` for
  * the matching element class.
  */
 object VirtualListRenderer {

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,16 +1,16 @@
-## nativephp/native-ui
+## nativephp/mobile-ui
 
 Native UI components for NativePHP Mobile. Every element renders as a real
 platform primitive — Material3 on Android, SwiftUI on iOS — not a webview
 widget. Elements are declared in Blade with `<native:*>` tags or built
-programmatically with the fluent `Nativephp\NativeUi\Elements\*` API; both
+programmatically with the fluent `Native\Mobile\UI\Elements\*` API; both
 paths serialize to the same wire tree.
 
 ### Core rules
 
 - Visual styling is theme-driven ("Model 3"): buttons, inputs, toggles, and
   other controls take their colors, radii, and typography from the theme
-  (`Nativephp\NativeUi\Theme`). Use semantic props like `variant="primary"`
+  (`Native\Mobile\UI\Theme`). Use semantic props like `variant="primary"`
   instead of per-instance colors — per-instance visual overrides on these
   controls are intentionally ignored.
 - Bind state with `native:model="property"` (works on toggle, checkbox, chip,
@@ -134,7 +134,7 @@ Android). Both are also available fluently as `->a11yLabel()` / `->a11yHint()`.
 
 @verbatim
 <code-snippet name="Fluent a11y API" lang="php">
-use Nativephp\NativeUi\Elements\Button;
+use Native\Mobile\UI\Elements\Button;
 
 Button::make()
     ->icon('plus')

--- a/resources/ios/NativeUITheme.swift
+++ b/resources/ios/NativeUITheme.swift
@@ -6,7 +6,7 @@ import UIKit
 /// One coherent set of theme tokens (light OR dark). Exposed to SwiftUI
 /// renderers via the `\.nativeUITheme` environment value.
 ///
-/// The PHP side (`Nativephp\NativeUi\Theme::merge([...])`) is the source of
+/// The PHP side (`Native\Mobile\UI\Theme::merge([...])`) is the source of
 /// truth. Tokens arrive over the bridge via `NativeUI.Theme.Set`.
 struct NativeUITokens: Equatable {
     // Colors

--- a/resources/ios/NativeUIVirtualListRenderer.swift
+++ b/resources/ios/NativeUIVirtualListRenderer.swift
@@ -12,7 +12,7 @@ import Combine
 /// PHP only when the visible range is approaching the edge of the data
 /// PHP has already shipped. PHP's next render emits the new slice.
 ///
-/// See `Plugins/nativephp/native-ui/src/Elements/NativeVirtualList.php`
+/// See `Plugins/nativephp/mobile-ui/src/Elements/NativeVirtualList.php`
 /// for the matching element class.
 struct NativeUIVirtualListRenderer: View {
     let node: NativeUINode

--- a/resources/stubs/views/components/layouts/app.blade.php
+++ b/resources/stubs/views/components/layouts/app.blade.php
@@ -1,5 +1,5 @@
 {{--
-    Default page layout for nativephp/native-ui.
+    Default page layout for nativephp/mobile-ui.
 
     Drop your screen content inside an `<x-layouts.app>` tag:
 

--- a/src/Builders/Drawer.php
+++ b/src/Builders/Drawer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Builders;
+namespace Native\Mobile\UI\Builders;
 
 use Illuminate\View\View;
 use Native\Mobile\Edge\Element;
@@ -9,12 +9,12 @@ use Native\Mobile\Edge\Element;
  * Fluent builder for a content-agnostic side drawer (X-style side nav).
  *
  * A layout returns a Drawer from its `drawer()` method (provide it with the
- * {@see \Nativephp\NativeUi\Concerns\HasLayoutDrawer} trait). The content is any
+ * {@see \Native\Mobile\UI\Concerns\HasLayoutDrawer} trait). The content is any
  * Blade view (or pre-built Element), so devs can put whatever UI they want
  * inside:
  *
- *   use Nativephp\NativeUi\Builders\Drawer;
- *   use Nativephp\NativeUi\Concerns\HasLayoutDrawer;
+ *   use Native\Mobile\UI\Builders\Drawer;
+ *   use Native\Mobile\UI\Concerns\HasLayoutDrawer;
  *
  *   class AppLayout extends NativeLayout
  *   {
@@ -30,7 +30,7 @@ use Native\Mobile\Edge\Element;
  *
  * The native-ui chrome contributor renders the content through the screen's own
  * bound Blade path (so `@press` / wire bindings resolve against the screen) and
- * wraps it in an {@see \Nativephp\NativeUi\Elements\NativeDrawer} sentinel. The
+ * wraps it in an {@see \Native\Mobile\UI\Elements\NativeDrawer} sentinel. The
  * native drawer host hoists that out into a global, persistent drawer.
  */
 class Drawer

--- a/src/Builders/FloatingOverlay.php
+++ b/src/Builders/FloatingOverlay.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Builders;
+namespace Native\Mobile\UI\Builders;
 
 use Illuminate\View\View;
 use Native\Mobile\Edge\Element;
@@ -13,12 +13,12 @@ use Native\Mobile\Edge\Element;
  * null (or a builder wrapping nothing) leaves the screen untouched.
  *
  * A layout returns a FloatingOverlay from its `floatingOverlay()` method
- * (provide it with the {@see \Nativephp\NativeUi\Concerns\HasFloatingOverlay}
+ * (provide it with the {@see \Native\Mobile\UI\Concerns\HasFloatingOverlay}
  * trait). The content is any Blade view (or pre-built Element), so devs can
  * float whatever UI they want — a pill, a banner, a mini-player:
  *
- *   use Nativephp\NativeUi\Builders\FloatingOverlay;
- *   use Nativephp\NativeUi\Concerns\HasFloatingOverlay;
+ *   use Native\Mobile\UI\Builders\FloatingOverlay;
+ *   use Native\Mobile\UI\Concerns\HasFloatingOverlay;
  *
  *   class AppLayout extends NativeLayout
  *   {
@@ -37,7 +37,7 @@ use Native\Mobile\Edge\Element;
  *
  * The native-ui chrome contributor renders the content through the screen's own
  * bound Blade path (so `@press` / wire bindings resolve against the screen) and
- * wraps it in a {@see \Nativephp\NativeUi\Elements\FloatingOverlay} sentinel.
+ * wraps it in a {@see \Native\Mobile\UI\Elements\FloatingOverlay} sentinel.
  * The native floating-overlay host hoists that out onto a persistent top layer
  * over every screen routed under the layout.
  */

--- a/src/Components/ActivityIndicator.php
+++ b/src/Components/ActivityIndicator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Badge.php
+++ b/src/Components/Badge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/BareTextInput.php
+++ b/src/Components/BareTextInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/BottomSheet.php
+++ b/src/Components/BottomSheet.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 use Native\Mobile\Edge\NativeElementCollector;

--- a/src/Components/ButtonGroup.php
+++ b/src/Components/ButtonGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 use Native\Mobile\Edge\NativeElementCollector;

--- a/src/Components/Carousel.php
+++ b/src/Components/Carousel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Checkbox.php
+++ b/src/Components/Checkbox.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Chip.php
+++ b/src/Components/Chip.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/FilledTextInput.php
+++ b/src/Components/FilledTextInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/FloatingOverlay.php
+++ b/src/Components/FloatingOverlay.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 
 /**
  * Blade component for the `floating_overlay` sentinel. The floating overlay is
  * normally emitted by the chrome contributor (see
- * {@see \Nativephp\NativeUi\Concerns\HasFloatingOverlay}), so this tag is rarely
+ * {@see \Native\Mobile\UI\Concerns\HasFloatingOverlay}), so this tag is rarely
  * written by hand — it exists to satisfy the manifest's element/blade pairing
  * and so the native no-op renderer (`EmptyRenderer`) is registered for the
  * marker (the host consumes it before it would render in place).

--- a/src/Components/Icon.php
+++ b/src/Components/Icon.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/ListItem.php
+++ b/src/Components/ListItem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/ListSection.php
+++ b/src/Components/ListSection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/NativeDrawer.php
+++ b/src/Components/NativeDrawer.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 
 /**
  * Blade component for the `native_drawer` sentinel. The layout drawer is
  * normally emitted by the chrome contributor (see
- * {@see \Nativephp\NativeUi\Concerns\HasLayoutDrawer}), so this tag is rarely
+ * {@see \Native\Mobile\UI\Concerns\HasLayoutDrawer}), so this tag is rarely
  * written by hand — it exists to satisfy the manifest's element/blade pairing
  * and so the native no-op renderer (`EmptyRenderer`) is registered for the
  * marker.

--- a/src/Components/NativeList.php
+++ b/src/Components/NativeList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/NativeVirtualList.php
+++ b/src/Components/NativeVirtualList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/OutlinedTextInput.php
+++ b/src/Components/OutlinedTextInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/ProgressBar.php
+++ b/src/Components/ProgressBar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Radio.php
+++ b/src/Components/Radio.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/RadioGroup.php
+++ b/src/Components/RadioGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Select.php
+++ b/src/Components/Select.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Slider.php
+++ b/src/Components/Slider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Tab.php
+++ b/src/Components/Tab.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/TabRow.php
+++ b/src/Components/TabRow.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Toggle.php
+++ b/src/Components/Toggle.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Components/Webview.php
+++ b/src/Components/Webview.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Components;
+namespace Native\Mobile\UI\Components;
 
 use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
 

--- a/src/Concerns/HasFloatingOverlay.php
+++ b/src/Concerns/HasFloatingOverlay.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Nativephp\NativeUi\Concerns;
+namespace Native\Mobile\UI\Concerns;
 
 use Native\Mobile\Edge\NativeComponent;
-use Nativephp\NativeUi\Builders\FloatingOverlay;
+use Native\Mobile\UI\Builders\FloatingOverlay;
 
 /**
  * Add a content-agnostic floating overlay (a pill/banner that hovers above the

--- a/src/Concerns/HasLayoutDrawer.php
+++ b/src/Concerns/HasLayoutDrawer.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Nativephp\NativeUi\Concerns;
+namespace Native\Mobile\UI\Concerns;
 
 use Native\Mobile\Edge\NativeComponent;
-use Nativephp\NativeUi\Builders\Drawer;
+use Native\Mobile\UI\Builders\Drawer;
 
 /**
  * Add a content-agnostic side drawer (X-style side nav) to a `NativeLayout`.

--- a/src/Concerns/InteractsWithDrawer.php
+++ b/src/Concerns/InteractsWithDrawer.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Nativephp\NativeUi\Concerns;
+namespace Native\Mobile\UI\Concerns;
 
-use Nativephp\NativeUi\Builders\Drawer;
+use Native\Mobile\UI\Builders\Drawer;
 
 /**
  * Per-screen control over the layout's side drawer. `use` this trait on a

--- a/src/Concerns/InteractsWithFloatingOverlay.php
+++ b/src/Concerns/InteractsWithFloatingOverlay.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Nativephp\NativeUi\Concerns;
+namespace Native\Mobile\UI\Concerns;
 
-use Nativephp\NativeUi\Builders\FloatingOverlay;
+use Native\Mobile\UI\Builders\FloatingOverlay;
 
 /**
  * Per-screen control over the layout's floating overlay. `use` this trait on a

--- a/src/Concerns/ResolvesColorValues.php
+++ b/src/Concerns/ResolvesColorValues.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Concerns;
+namespace Native\Mobile\UI\Concerns;
 
 use Native\Mobile\Edge\TailwindParser;
 

--- a/src/Console/CopyFontsCommand.php
+++ b/src/Console/CopyFontsCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Console;
+namespace Native\Mobile\UI\Console;
 
 use Native\Mobile\Plugins\Commands\NativePluginHookCommand;
 

--- a/src/Console/FontCommand.php
+++ b/src/Console/FontCommand.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Nativephp\NativeUi\Console;
+namespace Native\Mobile\UI\Console;
 
 use Illuminate\Console\Command;
-use Nativephp\NativeUi\Fonts\GoogleFonts;
+use Native\Mobile\UI\Fonts\GoogleFonts;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;

--- a/src/Console/GenerateIconsCommand.php
+++ b/src/Console/GenerateIconsCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Console;
+namespace Native\Mobile\UI\Console;
 
 use Illuminate\Console\Command;
 
@@ -17,7 +17,7 @@ use Illuminate\Console\Command;
  * The SF Symbols catalog has no public web URL — Apple ships it as a
  * plist bundled with the SF Symbols.app. To refresh the SF snapshot,
  * extract symbol names from the app on a Mac and update
- * `vendor/nativephp/native-ui/resources/icons/sf-symbols.json` (or
+ * `vendor/nativephp/mobile-ui/resources/icons/sf-symbols.json` (or
  * publish the snapshots into your app first to own them).
  *
  * Output goes to your app at `app/Icons/`. The namespace is `App\Icons`

--- a/src/Elements/ActivityIndicator.php
+++ b/src/Elements/ActivityIndicator.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
-use Nativephp\NativeUi\Concerns\ResolvesColorValues;
+use Native\Mobile\UI\Concerns\ResolvesColorValues;
 
 /**
  * Circular activity indicator (spinner). Always indeterminate — use

--- a/src/Elements/Badge.php
+++ b/src/Elements/Badge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/BareTextInput.php
+++ b/src/Elements/BareTextInput.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
-use Nativephp\NativeUi\Concerns\ResolvesColorValues;
+use Native\Mobile\UI\Concerns\ResolvesColorValues;
 
 /**
  * Chromeless text input — a SwiftUI `TextField` (iOS) / Compose

--- a/src/Elements/BaseTextInput.php
+++ b/src/Elements/BaseTextInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/BottomSheet.php
+++ b/src/Elements/BottomSheet.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Button.php
+++ b/src/Elements/Button.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
@@ -28,7 +28,7 @@ use Native\Mobile\Icon\IosSymbol;
  *
  * Per Model 3 customization (theme-only), there is intentionally NO per-instance
  * color, background, border, radius, shadow, font-size, or font-weight. All
- * visual styling comes from the theme (`Nativephp\NativeUi\Theme`). For full
+ * visual styling comes from the theme (`Native\Mobile\UI\Theme`). For full
  * visual control, drop to `<pressable>` with your own content.
  */
 class Button extends Element

--- a/src/Elements/ButtonGroup.php
+++ b/src/Elements/ButtonGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Carousel.php
+++ b/src/Elements/Carousel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Checkbox.php
+++ b/src/Elements/Checkbox.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Chip.php
+++ b/src/Elements/Chip.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Concerns\HasPlatformIcon;
 use Native\Mobile\Edge\CallbackRegistry;

--- a/src/Elements/FilledTextInput.php
+++ b/src/Elements/FilledTextInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 /**
  * Filled text input — renders as Material3 `TextField` (filled) on Android

--- a/src/Elements/FloatingOverlay.php
+++ b/src/Elements/FloatingOverlay.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Icon.php
+++ b/src/Elements/Icon.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
 use Native\Mobile\Icon\AndroidSymbol;
 use Native\Mobile\Icon\IconResolver;
 use Native\Mobile\Icon\IosSymbol;
-use Nativephp\NativeUi\Concerns\ResolvesColorValues;
+use Native\Mobile\UI\Concerns\ResolvesColorValues;
 
 class Icon extends Element
 {

--- a/src/Elements/ListItem.php
+++ b/src/Elements/ListItem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
@@ -8,7 +8,7 @@ use Native\Mobile\Edge\Layouts\Builders\NavAction;
 use Native\Mobile\Icon\AndroidSymbol;
 use Native\Mobile\Icon\IconResolver;
 use Native\Mobile\Icon\IosSymbol;
-use Nativephp\NativeUi\Concerns\ResolvesColorValues;
+use Native\Mobile\UI\Concerns\ResolvesColorValues;
 
 class ListItem extends Element
 {

--- a/src/Elements/ListSection.php
+++ b/src/Elements/ListSection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Modal.php
+++ b/src/Elements/Modal.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/NativeDrawer.php
+++ b/src/Elements/NativeDrawer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/NativeList.php
+++ b/src/Elements/NativeList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/NativeVirtualList.php
+++ b/src/Elements/NativeVirtualList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/OutlinedTextInput.php
+++ b/src/Elements/OutlinedTextInput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 /**
  * Outlined text input — renders as Material3 `OutlinedTextField` on Android

--- a/src/Elements/ProgressBar.php
+++ b/src/Elements/ProgressBar.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
-use Nativephp\NativeUi\Concerns\ResolvesColorValues;
+use Native\Mobile\UI\Concerns\ResolvesColorValues;
 
 /**
  * Linear progress bar. Value in [0.0, 1.0]. Omit `value` for indeterminate

--- a/src/Elements/Radio.php
+++ b/src/Elements/Radio.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/RadioGroup.php
+++ b/src/Elements/RadioGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Slider.php
+++ b/src/Elements/Slider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Tab.php
+++ b/src/Elements/Tab.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Concerns\HasPlatformIcon;
 use Native\Mobile\Edge\CallbackRegistry;

--- a/src/Elements/TabRow.php
+++ b/src/Elements/TabRow.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Toggle.php
+++ b/src/Elements/Toggle.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Elements/Webview.php
+++ b/src/Elements/Webview.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Elements;
+namespace Native\Mobile\UI\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;

--- a/src/Fonts/GoogleFonts.php
+++ b/src/Fonts/GoogleFonts.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi\Fonts;
+namespace Native\Mobile\UI\Fonts;
 
 /**
  * Pure helpers for the `native:font` Google Fonts downloader — URL spec

--- a/src/NativeUIServiceProvider.php
+++ b/src/NativeUIServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi;
+namespace Native\Mobile\UI;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\View;
@@ -9,13 +9,13 @@ use Native\Mobile\Edge\Element;
 use Native\Mobile\Edge\Layouts\NativeLayout;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\TailwindParser;
-use Nativephp\NativeUi\Builders\Drawer;
-use Nativephp\NativeUi\Builders\FloatingOverlay as FloatingOverlayBuilder;
-use Nativephp\NativeUi\Console\CopyFontsCommand;
-use Nativephp\NativeUi\Console\FontCommand;
-use Nativephp\NativeUi\Console\GenerateIconsCommand;
-use Nativephp\NativeUi\Elements\FloatingOverlay as FloatingOverlayElement;
-use Nativephp\NativeUi\Elements\NativeDrawer;
+use Native\Mobile\UI\Builders\Drawer;
+use Native\Mobile\UI\Builders\FloatingOverlay as FloatingOverlayBuilder;
+use Native\Mobile\UI\Console\CopyFontsCommand;
+use Native\Mobile\UI\Console\FontCommand;
+use Native\Mobile\UI\Console\GenerateIconsCommand;
+use Native\Mobile\UI\Elements\FloatingOverlay as FloatingOverlayElement;
+use Native\Mobile\UI\Elements\NativeDrawer;
 
 class NativeUIServiceProvider extends ServiceProvider
 {
@@ -136,8 +136,8 @@ class NativeUIServiceProvider extends ServiceProvider
      * hoists it onto a top layer over the content.
      *
      * Discovery is via `method_exists`, so layouts/screens opt in by using the
-     * {@see \Nativephp\NativeUi\Concerns\HasFloatingOverlay} /
-     * {@see \Nativephp\NativeUi\Concerns\InteractsWithFloatingOverlay} traits (or
+     * {@see \Native\Mobile\UI\Concerns\HasFloatingOverlay} /
+     * {@see \Native\Mobile\UI\Concerns\InteractsWithFloatingOverlay} traits (or
      * by declaring the methods themselves) — core never knows.
      */
     protected function registerFloatingOverlay(): void

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Nativephp\NativeUi;
+namespace Native\Mobile\UI;
 
 use Native\Mobile\Edge\TailwindParser;
 

--- a/tests/A11yTest.php
+++ b/tests/A11yTest.php
@@ -4,12 +4,12 @@ use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\ElementRegistry;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\TailwindParser;
-use Nativephp\NativeUi\Elements\Button;
-use Nativephp\NativeUi\Elements\Icon;
-use Nativephp\NativeUi\Elements\ListItem;
-use Nativephp\NativeUi\Elements\Tab;
-use Nativephp\NativeUi\Elements\TabRow;
-use Nativephp\NativeUi\Elements\Toggle;
+use Native\Mobile\UI\Elements\Button;
+use Native\Mobile\UI\Elements\Icon;
+use Native\Mobile\UI\Elements\ListItem;
+use Native\Mobile\UI\Elements\Tab;
+use Native\Mobile\UI\Elements\TabRow;
+use Native\Mobile\UI\Elements\Toggle;
 
 /**
  * Accessibility props (`HasA11y` trait + ListItem's trailing label):

--- a/tests/CollectorElementsTest.php
+++ b/tests/CollectorElementsTest.php
@@ -4,13 +4,13 @@ use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\ElementRegistry;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\TailwindParser;
-use Nativephp\NativeUi\Elements\BareTextInput;
-use Nativephp\NativeUi\Elements\Button;
-use Nativephp\NativeUi\Elements\Checkbox;
-use Nativephp\NativeUi\Elements\ProgressBar;
-use Nativephp\NativeUi\Elements\Radio;
-use Nativephp\NativeUi\Elements\RadioGroup;
-use Nativephp\NativeUi\Elements\Toggle;
+use Native\Mobile\UI\Elements\BareTextInput;
+use Native\Mobile\UI\Elements\Button;
+use Native\Mobile\UI\Elements\Checkbox;
+use Native\Mobile\UI\Elements\ProgressBar;
+use Native\Mobile\UI\Elements\Radio;
+use Native\Mobile\UI\Elements\RadioGroup;
+use Native\Mobile\UI\Elements\Toggle;
 
 /**
  * Attribute → wire-prop behavior of this plugin's elements, driven

--- a/tests/ElementColorTest.php
+++ b/tests/ElementColorTest.php
@@ -4,11 +4,11 @@ use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\ElementRegistry;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\TailwindParser;
-use Nativephp\NativeUi\Elements\ActivityIndicator;
-use Nativephp\NativeUi\Elements\BareTextInput;
-use Nativephp\NativeUi\Elements\Icon;
-use Nativephp\NativeUi\Elements\ListItem;
-use Nativephp\NativeUi\Elements\ProgressBar;
+use Native\Mobile\UI\Elements\ActivityIndicator;
+use Native\Mobile\UI\Elements\BareTextInput;
+use Native\Mobile\UI\Elements\Icon;
+use Native\Mobile\UI\Elements\ListItem;
+use Native\Mobile\UI\Elements\ProgressBar;
 
 /**
  * Element color props share the theme config's authoring grammar:

--- a/tests/FloatingOverlayTest.php
+++ b/tests/FloatingOverlayTest.php
@@ -2,11 +2,11 @@
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\NativeComponent;
-use Nativephp\NativeUi\Builders\FloatingOverlay as FloatingOverlayBuilder;
-use Nativephp\NativeUi\Concerns\InteractsWithFloatingOverlay;
-use Nativephp\NativeUi\Elements\Chip;
-use Nativephp\NativeUi\Elements\FloatingOverlay;
-use Nativephp\NativeUi\NativeUIServiceProvider;
+use Native\Mobile\UI\Builders\FloatingOverlay as FloatingOverlayBuilder;
+use Native\Mobile\UI\Concerns\InteractsWithFloatingOverlay;
+use Native\Mobile\UI\Elements\Chip;
+use Native\Mobile\UI\Elements\FloatingOverlay;
+use Native\Mobile\UI\NativeUIServiceProvider;
 
 /**
  * The floating-overlay layout hook: a content-agnostic pill/banner that floats

--- a/tests/FontTypographyTest.php
+++ b/tests/FontTypographyTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use Native\Mobile\Edge\CallbackRegistry;
-use Nativephp\NativeUi\Elements\Button;
-use Nativephp\NativeUi\Elements\FilledTextInput;
-use Nativephp\NativeUi\Elements\OutlinedTextInput;
+use Native\Mobile\UI\Elements\Button;
+use Native\Mobile\UI\Elements\FilledTextInput;
+use Native\Mobile\UI\Elements\OutlinedTextInput;
 
 /**
  * Typography wire props on native-ui elements:

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Nativephp\NativeUi\Fonts\GoogleFonts;
+use Native\Mobile\UI\Fonts\GoogleFonts;
 
 /**
  * Pure-logic tests for `native:font` — css2 URL spec building, @font-face

--- a/tests/IconEnumAttrTest.php
+++ b/tests/IconEnumAttrTest.php
@@ -6,7 +6,7 @@ use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Icon\AndroidSymbol;
 use Native\Mobile\Icon\IosSymbol;
 use Native\Mobile\Platform;
-use Nativephp\NativeUi\Elements\Icon;
+use Native\Mobile\UI\Elements\Icon;
 
 /**
  * `<icon :ios="Ios::House" :android="Android::Home"/>` — platform enum

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -95,13 +95,13 @@ describe('Native Renderers', function () {
 });
 
 describe('Composer Configuration', function () {
-    it('has valid composer.json with UI plugin type', function () {
+    it('has valid composer.json with nativephp-plugin type', function () {
         $composerPath = $this->pluginPath . '/composer.json';
         expect(file_exists($composerPath))->toBeTrue();
 
         $composer = json_decode(file_get_contents($composerPath), true);
 
         expect(json_last_error())->toBe(JSON_ERROR_NONE);
-        expect($composer['type'])->toBe('nativephp-ui-plugin');
+        expect($composer['type'])->toBe('nativephp-plugin');
     });
 });

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -41,8 +41,8 @@ describe('Plugin Manifest', function () {
 
         $button = collect($manifest['components'])->firstWhere('type', 'button');
         expect($button)->not->toBeNull();
-        expect($button['element'])->toBe('Nativephp\\NativeUi\\Elements\\Button');
-        expect($button['blade'])->toBe('Nativephp\\NativeUi\\Components\\Button');
+        expect($button['element'])->toBe('Native\\Mobile\\UI\\Elements\\Button');
+        expect($button['blade'])->toBe('Native\\Mobile\\UI\\Components\\Button');
         expect($button['android_renderer'])->not->toBeEmpty();
         expect($button['ios_renderer'])->not->toBeEmpty();
     });

--- a/tests/ThemeColorTest.php
+++ b/tests/ThemeColorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Native\Mobile\JumpBridge;
-use Nativephp\NativeUi\Theme;
+use Native\Mobile\UI\Theme;
 
 beforeEach(function () {
     // Keep Theme::pushToNative() off the wire: plain Pest has no Laravel


### PR DESCRIPTION
## What

Renames the package and PHP namespace to match the repo's new home:

- **Package**: `nativephp/native-ui` → `nativephp/mobile-ui`
- **Namespace**: `Nativephp\NativeUi` → `Native\Mobile\UI` — brings the plugin under the framework's `Native\Mobile` namespace root, alongside `Native\Mobile\Edge` from `nativephp/mobile`

90 files changed: every class in `src/` and `tests/`, the PSR-4 mapping + provider FQCN in `composer.json`, element/blade FQCNs and the plugin name in `nativephp.json`, docs, and namespace mentions in Swift/Kotlin comments (comment-only on the native side — no code changes there).

Also updates composer.json metadata: description, `type: nativephp-plugin`, authors, funding, and pins `nativephp/mobile` to `^4.0`.

## Intentionally unchanged

These are separate identities with their own blast radius, left for follow-ups if wanted:

- Manifest bridge namespace `"NativeUI"` (drives wire naming like `NativeUI.Theme.Set`)
- Config surface: `config/native-ui.php`, the `native-ui` config key, `native-ui-config` / `native-ui-layouts` publish tags
- `NativeUIServiceProvider` class name and artisan command signatures
- Kotlin package `com.nativephp.plugins.native_ui` and Swift `NativeUI*` renderer prefixes

## Verification

- `composer validate` clean
- Optimized autoload dump: all 70 `src/` classes resolve under the new PSR-4 prefix, zero mismatch warnings
- `php -l` passes on every tracked PHP file
- No leftovers of `Nativephp`, `NativeUi`, or `nativephp/native-ui` anywhere in the tree

## Note

Stacked on #7 (`feat/webview-element`) — merge that first; GitHub will retarget this to `main` when the base branch is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)