### PR TITLE
fix(ios): synthesize oblique for italic on single-style custom fonts

### DIFF
--- a/resources/ios/NativeUIFontResolver.swift
+++ b/resources/ios/NativeUIFontResolver.swift
@@ -18,7 +18,14 @@ enum NativeUIFontResolver {
     // token → PostScript name. A cached `.some(nil)` records "looked up,
     // not found" so misses aren't retried every frame.
     private static var cache: [String: String?] = [:]
+    // PostScript name → whether CoreText can apply a REAL italic trait.
+    private static var italicTraitCache: [String: Bool] = [:]
     private static let lock = NSLock()
+
+    /// Slant for synthesized obliques: tan(14°), matching Android's fake
+    /// italic (`textSkewX = -0.25`) so a single-style font leans the same
+    /// amount on both platforms.
+    private static let obliqueSkew: CGFloat = 0.25
 
     /// Semantic aliases from the theme payload's `fonts` map (e.g.
     /// "accent" → "DynaPuff-Regular"). Consulted before file lookup, so any
@@ -30,10 +37,42 @@ enum NativeUIFontResolver {
 
     /// A SwiftUI `Font` for a bundled token at `size`, or nil to fall back.
     /// `size` is used as-is (callers pass an already-Dynamic-Type-scaled value).
-    static func font(_ token: String, size: CGFloat) -> Font? {
+    ///
+    /// With `italic`, a font whose family has a real italic face is returned
+    /// upright — the caller's `Text.italic()` / `Font.italic()` selects the
+    /// true face via the trait. A single-style font (no italic face) gets a
+    /// synthesized oblique here instead, because SwiftUI's trait path silently
+    /// renders such fonts upright while Android fakes the slant — the exact
+    /// cross-platform mismatch this resolves.
+    static func font(_ token: String, size: CGFloat, italic: Bool = false) -> Font? {
         guard let name = postScriptName(for: token) else { return nil }
 
+        if italic, !supportsItalicTrait(name) {
+            let matrix = CGAffineTransform(a: 1, b: 0, c: obliqueSkew, d: 1, tx: 0, ty: 0)
+            let descriptor = UIFontDescriptor(name: name, matrix: matrix)
+            return Font(UIFont(descriptor: descriptor, size: size))
+        }
+
         return Font.custom(name, size: size)
+    }
+
+    /// Whether CoreText can produce a genuinely italic face for this
+    /// PostScript name. `CTFontCreateCopyWithSymbolicTraits` returns nil when
+    /// the family has nothing to satisfy the trait — the case where SwiftUI's
+    /// `.italic()` becomes a silent no-op.
+    private static func supportsItalicTrait(_ postScriptName: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let cached = italicTraitCache[postScriptName] {
+            return cached
+        }
+
+        let base = CTFontCreateWithName(postScriptName as CFString, 12, nil)
+        let supported = CTFontCreateCopyWithSymbolicTraits(base, 0, nil, .italicTrait, .italicTrait) != nil
+        italicTraitCache[postScriptName] = supported
+
+        return supported
     }
 
     /// Extra `.lineSpacing` needed to hit a Tailwind `leading` target for the

--- a/resources/ios/NativeUITextRenderer.swift
+++ b/resources/ios/NativeUITextRenderer.swift
@@ -66,7 +66,7 @@ struct NativeUITextRenderer: View {
             }()
 
             styledText
-                .nuiScaledFont(size: CGFloat(fontSize), weight: fontWeight, design: fontDesign, fontName: fontName.isEmpty ? nil : fontName)
+                .nuiScaledFont(size: CGFloat(fontSize), weight: fontWeight, design: fontDesign, fontName: fontName.isEmpty ? nil : fontName, italic: isItalic)
                 .lineSpacing(lineSpacingValue)
                 .foregroundColor(Color(argb: color))
                 .multilineTextAlignment(textAlign)
@@ -190,7 +190,7 @@ struct NativeUITextRenderer: View {
 
         var font: Font
         if !runFontName.isEmpty,
-           let custom = NativeUIFontResolver.font(runFontName, size: CGFloat(ctx.fontSize)) {
+           let custom = NativeUIFontResolver.font(runFontName, size: CGFloat(ctx.fontSize), italic: ctx.italic) {
             font = custom.weight(runWeight)
         } else {
             font = Font.system(
@@ -199,6 +199,9 @@ struct NativeUITextRenderer: View {
                 design: resolveFontDesign(ctx.fontFamilyInt)
             )
         }
+        // Real italic faces (and the system font) take the trait here; a
+        // single-style custom font already came back synthetically obliqued
+        // from the resolver, on which `.italic()` is a harmless no-op.
         if ctx.italic, #available(iOS 16.0, *) { font = font.italic() }
         run.font = font
 

--- a/resources/ios/NativeUITheme.swift
+++ b/resources/ios/NativeUITheme.swift
@@ -208,12 +208,14 @@ struct NUIScaledFontModifier: ViewModifier {
     private let weight: Font.Weight
     private let design: Font.Design
     private let fontName: String?
+    private let italic: Bool
 
-    init(size: CGFloat, weight: Font.Weight, design: Font.Design, fontName: String?) {
+    init(size: CGFloat, weight: Font.Weight, design: Font.Design, fontName: String?, italic: Bool) {
         _size = ScaledMetric(wrappedValue: size, relativeTo: .body)
         self.weight = weight
         self.design = design
         self.fontName = fontName
+        self.italic = italic
     }
 
     @ObservedObject private var themeStore = NativeUITheme.shared
@@ -224,7 +226,10 @@ struct NUIScaledFontModifier: ViewModifier {
         // selects/synthesizes it within the family). Unknown names — or none —
         // fall back to the system font unchanged. `size` is already Dynamic-
         // Type-scaled by `@ScaledMetric`, so the custom font uses it as-is.
-        if let name = effectiveFontName, let custom = NativeUIFontResolver.font(name, size: size) {
+        // `italic` only matters to the resolver for single-style fonts (it
+        // synthesizes an oblique); real italic faces and the system font get
+        // the trait from the caller's `Text.italic()`.
+        if let name = effectiveFontName, let custom = NativeUIFontResolver.font(name, size: size, italic: italic) {
             content.font(custom.weight(weight))
         } else {
             content.font(.system(size: size, weight: weight, design: design))
@@ -249,8 +254,8 @@ extension View {
     /// with the user's accessibility settings. Pass `fontName` (a bundled font
     /// token) to render in a custom font, falling back to the system font when
     /// it can't be resolved.
-    func nuiScaledFont(size: CGFloat, weight: Font.Weight = .regular, design: Font.Design = .default, fontName: String? = nil) -> some View {
-        modifier(NUIScaledFontModifier(size: size, weight: weight, design: design, fontName: fontName))
+    func nuiScaledFont(size: CGFloat, weight: Font.Weight = .regular, design: Font.Design = .default, fontName: String? = nil, italic: Bool = false) -> some View {
+        modifier(NUIScaledFontModifier(size: size, weight: weight, design: design, fontName: fontName, italic: italic))
     }
 
     /// Ensures a minimum 44×44pt hit target (Apple HIG) without changing the


### PR DESCRIPTION
## Problem

`<text font="accent" class="italic">` renders slanted on Android but upright on iOS whenever the custom font has no real italic face (true of most single-style Google Fonts display faces — Audiowide, DynaPuff, Rock Salt, and jump's wordmark is the live example).

- **Android** (`TextRenderer.kt`): Compose gets `FontStyle.Italic`; when the family lacks an italic font, the platform synthesizes one (`textSkewX = -0.25`).
- **iOS** (`NativeUITextRenderer.swift`): `Text.italic()` requests the italic symbolic trait; when the family can't satisfy it, CoreText silently falls back and the text stays upright. No synthesis anywhere in the chain.

## Fix

`NativeUIFontResolver.font(_:size:)` gains an `italic:` flag:

- If CoreText can produce a real italic face (`CTFontCreateCopyWithSymbolicTraits` non-nil, cached per PostScript name), the font is returned upright as before — the existing `Text.italic()` / `Font.italic()` call sites select the true face.
- If it can't, the resolver returns the font skewed by **tan(14°) ≈ 0.25** via a `UIFontDescriptor` matrix — deliberately matching Android's fake-italic slant so the two platforms lean the same amount.

Both text paths pass the flag through: the leaf path via a new `italic:` parameter on `nuiScaledFont` (defaulted, so all other call sites are untouched), and the composed-run path directly. The theme-default font (`fonts.default`) benefits too, since resolution runs through the same code.

No prop/contract changes; Android untouched.

## Testing

- `swiftc -parse` clean on the three edited files (full type-check requires the generated Xcode project).
- Needs a device/simulator pass on a scaffolded app to eyeball the slant — e.g. jump's home screen wordmark (`font="accent" italic` → Audiowide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)