### PR TITLE
fix(ios): skew leaf text at the view level so synthetic obliques don't clip

### DIFF
--- a/resources/ios/NativeUIFontResolver.swift
+++ b/resources/ios/NativeUIFontResolver.swift
@@ -44,6 +44,13 @@ enum NativeUIFontResolver {
     /// synthesized oblique here instead, because SwiftUI's trait path silently
     /// renders such fonts upright while Android fakes the slant — the exact
     /// cross-platform mismatch this resolves.
+    ///
+    /// Matrix-skewed glyphs lean PAST their advance widths, and SwiftUI's
+    /// text renderer clips each line to those advances — so a line ENDING in
+    /// an oblique run loses the top-right of its last glyph. Leaf text
+    /// therefore skews at the view level instead (`obliqueTransform`); this
+    /// font-level path remains for inline composed runs, where a per-view
+    /// transform can't reach and mid-line runs hide the overhang naturally.
     static func font(_ token: String, size: CGFloat, italic: Bool = false) -> Font? {
         guard let name = postScriptName(for: token) else { return nil }
 
@@ -54,6 +61,33 @@ enum NativeUIFontResolver {
         }
 
         return Font.custom(name, size: size)
+    }
+
+    /// Whether an italic request for this token needs a synthesized oblique
+    /// (custom font resolves, but its family has no real italic face).
+    static func needsSyntheticOblique(_ token: String) -> Bool {
+        guard let name = postScriptName(for: token) else { return false }
+
+        return !supportsItalicTrait(name)
+    }
+
+    /// View-space skew for a synthetic oblique on LEAF text: the Text keeps
+    /// its upright font (complete raster, nothing clipped) and the rendered
+    /// view is slanted after the fact — the same draw-time model as Android's
+    /// `textSkewX`. Anchored at the first baseline (`ascender` below the top
+    /// in view coordinates, where y grows downward), so the baseline stays
+    /// put and glyph tops lean right. On wrapped text later baselines sit
+    /// lower and drift slightly left — the trade against the font-matrix
+    /// path's hard clip at every line end.
+    static func obliqueTransform(_ token: String, size: CGFloat) -> CGAffineTransform {
+        let ascent: CGFloat = {
+            if let name = postScriptName(for: token), let font = UIFont(name: name, size: size) {
+                return font.ascender
+            }
+            return UIFont.systemFont(ofSize: size).ascender
+        }()
+
+        return CGAffineTransform(a: 1, b: 0, c: -obliqueSkew, d: 1, tx: obliqueSkew * ascent, ty: 0)
     }
 
     /// Whether CoreText can produce a genuinely italic face for this

--- a/resources/ios/NativeUITheme.swift
+++ b/resources/ios/NativeUITheme.swift
@@ -226,11 +226,18 @@ struct NUIScaledFontModifier: ViewModifier {
         // selects/synthesizes it within the family). Unknown names — or none —
         // fall back to the system font unchanged. `size` is already Dynamic-
         // Type-scaled by `@ScaledMetric`, so the custom font uses it as-is.
-        // `italic` only matters to the resolver for single-style fonts (it
-        // synthesizes an oblique); real italic faces and the system font get
-        // the trait from the caller's `Text.italic()`.
-        if let name = effectiveFontName, let custom = NativeUIFontResolver.font(name, size: size, italic: italic) {
-            content.font(custom.weight(weight))
+        // `italic` only matters for single-style custom fonts: the font stays
+        // upright (so SwiftUI rasterizes the full glyphs — a matrix-skewed
+        // font leans past its advances and gets clipped at line ends) and the
+        // rendered view is slanted instead. Real italic faces and the system
+        // font get the trait from the caller's `Text.italic()`.
+        if let name = effectiveFontName, let custom = NativeUIFontResolver.font(name, size: size) {
+            if italic, NativeUIFontResolver.needsSyntheticOblique(name) {
+                content.font(custom.weight(weight))
+                    .transformEffect(NativeUIFontResolver.obliqueTransform(name, size: size))
+            } else {
+                content.font(custom.weight(weight))
+            }
         } else {
             content.font(.system(size: size, weight: weight, design: design))
         }


### PR DESCRIPTION
Follow-up to #12, fixing the clipping it introduced.

## Problem

The font-matrix oblique leans glyphs past their advance widths, and SwiftUI's text renderer clips each line's raster to those advances. Net effect: the last glyph of an obliqued line loses its top-right corner — on jump's home screen the 72pt JUMP wordmark renders with the P's bowl sliced vertically. This is a known SwiftUI `Text` behavior (same mechanism that [crops negative-tracking text](https://developer.apple.com/forums/thread/735210)); no outside padding or frame can reveal the missing pixels because the raster itself is cut.

## Fix

Leaf text (`NUIScaledFontModifier`) now keeps the **upright** font — the raster is complete, nothing overhangs — and slants the rendered view with a `transformEffect` skew, which is exactly Android's draw-time `textSkewX` model. The skew is anchored at the first baseline (`ascender` below the view top in y-down view coordinates), so the baseline stays put, glyph tops lean right by the same tan(14°), and layout metrics are untouched.

Trade-off, documented in code: on *wrapped* leaf text, baselines below the first drift slightly left of the anchor (~25% of line height per line). That only affects single-style fonts asked for italic on multi-line text, versus a guaranteed hard clip at every line end with the matrix approach.

Inline composed runs (`makeRun`) keep the font-matrix path from #12 — a per-view transform can't target a single run. Mid-line the overhang lands in the next run's space harmlessly; only a line *ending* in an oblique run can still clip, noted on the resolver.

## Testing

- `swiftc -parse` clean on both edited files.
- Needs an eyeball on device: jump home screen — the P should now be whole, slant unchanged, wordmark position unmoved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)