### PR TITLE
Fix Pint incompatibility in generated icon enums

### DIFF
--- a/src/Console/GenerateIconsCommand.php
+++ b/src/Console/GenerateIconsCommand.php
@@ -212,8 +212,6 @@ class GenerateIconsCommand extends Command
         ?string $variant,
         string $blurb,
     ): void {
-        $longestCaseName = max(array_map('strlen', array_keys($cases)) ?: [0]);
-
         $lines = ['<?php', '', "namespace {$namespace};", '', "use {$interfaceFqn};", '', '/**', " * {$blurb}", ' *', ' * GENERATED FILE — do not hand-edit.', ' * Run `php artisan native-ui:generate-icons` to regenerate from', ' * `resources/icons/*.json` snapshots.', ' */', "enum {$class}: string implements {$interface}", '{'];
 
         if ($variant !== null) {
@@ -225,8 +223,7 @@ class GenerateIconsCommand extends Command
         }
 
         foreach ($cases as $case => $value) {
-            $padded = str_pad($case, $longestCaseName);
-            $lines[] = "    case {$padded} = '{$value}';";
+            $lines[] = "    case {$case} = '{$value}';";
         }
 
         $lines[] = '}';


### PR DESCRIPTION
`native-ui:generate-icons` column-aligns enum case values with `str_pad`, which trips Pint's `binary_operator_spaces` fixer in any app that lints `app/Icons/` causing CI failures or churn on every regenerate.

This drops the alignment so cases emit with a single space around `=`. Regenerated output now passes `pint --test` out of the box and is byte-identical apart from whitespace. No behavioral change.