### PR TITLE
fix: restore the font-family token dropped from the config stub by #15

### DIFF
--- a/config/native-ui.php
+++ b/config/native-ui.php
@@ -127,6 +127,13 @@ return [
         'font-lg' => 20,
         'font-xl' => 24,
 
+        // 'System' resolves to the platform default (San Francisco on iOS, Roboto on Android).
+        // Set a bundled font token to apply it app-wide — a file from your app's
+        // resources/fonts/ minus the extension (e.g. 'Inter-Regular'). Download one
+        // with `php artisan native:font Inter`. The fonts 'default' alias below,
+        // when set, supersedes this token. Per-element `font` attributes and
+        // font-serif / font-mono classes still win over both.
+        'font-family' => 'System',
     ],
 
     /*


### PR DESCRIPTION
#15's config stub came from a lineage predating e182ce5 (semantic font aliases), so the squash silently dropped the theme's `'font-family' => 'System'` token — `GoogleFontsTest > it matches the shipped config stub` now fails on main because `replaceDefaultFontToken` finds nothing to rewrite.

This restores the token (with its original guidance, plus a note that the fonts `default` alias supersedes it when set). Verified locally that the test's regex matches the restored stub exactly once and produces the expected replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)