### PR TITLE
feat: app-wide default font moves to the fonts 'default' alias

### DIFF
--- a/config/native-ui.php
+++ b/config/native-ui.php
@@ -127,13 +127,6 @@ return [
         'font-lg' => 20,
         'font-xl' => 24,
 
-        // 'System' resolves to the platform default (San Francisco on iOS, Roboto on Android).
-        // Set a bundled font token to apply it app-wide — a file from your app's
-        // resources/fonts/ minus the extension (e.g. 'Inter-Regular'). Download one
-        // with `php artisan native:font Inter`. The fonts 'default' alias below,
-        // when set, supersedes this token. Per-element `font` attributes and
-        // font-serif / font-mono classes still win over both.
-        'font-family' => 'System',
     ],
 
     /*

--- a/src/Console/FontCommand.php
+++ b/src/Console/FontCommand.php
@@ -39,7 +39,7 @@ class FontCommand extends Command
         {family* : Google Fonts family name(s), e.g. Lobster or "Rock Salt"}
         {--weights=400 : Comma-separated weights to download (e.g. 400,700)}
         {--italic : Also download italic styles for each weight}
-        {--default : Set the downloaded font as the app-wide default (theme font-family)}';
+        {--default : Set the downloaded font as the app-wide default (fonts default alias)}';
 
     protected $description = 'Download Google Fonts into resources/fonts/ for use with font="…"';
 
@@ -124,9 +124,9 @@ class FontCommand extends Command
     }
 
     /**
-     * Offer to set the downloaded font as the app-wide default — the theme's
-     * `font-family` token, which every text renderer falls back to when an
-     * element has no `font` of its own.
+     * Offer to set the downloaded font as the app-wide default — the
+     * `default` alias in the config's fonts block, which every text renderer
+     * falls back to when an element has no `font` of its own.
      */
     private function maybeSetDefault(array $tokens): void
     {
@@ -156,8 +156,8 @@ class FontCommand extends Command
         $updated = GoogleFonts::replaceDefaultFontToken(file_get_contents($configPath), $token);
 
         if ($updated === null) {
-            $this->warn("Couldn't find a 'font-family' key in config/native-ui.php — add it to the theme block yourself:");
-            $this->line("  'font-family' => '{$token}',");
+            $this->warn("Couldn't find a 'fonts' block in config/native-ui.php — add the default alias yourself:");
+            $this->line("  'fonts' => ['default' => '{$token}'],");
 
             return;
         }

--- a/src/Fonts/GoogleFonts.php
+++ b/src/Fonts/GoogleFonts.php
@@ -5,7 +5,7 @@ namespace Native\Mobile\UI\Fonts;
 /**
  * Pure helpers for the `native:font` Google Fonts downloader — URL spec
  * building, css2 response parsing, filename conventions, and the config
- * `font-family` rewrite. No framework dependencies so the logic is unit
+ * default-font rewrite. No framework dependencies so the logic is unit
  * testable without booting Laravel; `Console\FontCommand` does the I/O.
  */
 class GoogleFonts
@@ -23,7 +23,7 @@ class GoogleFonts
      */
     public static function familySpec(string $family, array $weights, bool $italic): string
     {
-        $name = str_replace(' ', '+', trim($family));
+        $name = str_replace(' ', '+', self::canonicalFamily($family));
 
         if ($weights === [400] && ! $italic) {
             return $name;
@@ -80,10 +80,20 @@ class GoogleFonts
         return empty($faces) ? null : array_values($faces);
     }
 
+    /**
+     * Family name as typed → canonical spaced form. `+` reads as a space —
+     * it's the css2 URL spelling users copy from fonts.google.com, so
+     * `Archivo+Black` means the "Archivo Black" family.
+     */
+    public static function canonicalFamily(string $family): string
+    {
+        return trim(str_replace('+', ' ', $family));
+    }
+
     /** Inter + 700 + italic → Inter-BoldItalic.ttf (Google's zip convention). */
     public static function filenameFor(string $family, int $weight, bool $italic): string
     {
-        $base = str_replace(' ', '', ucwords(trim($family)));
+        $base = str_replace(' ', '', ucwords(self::canonicalFamily($family)));
         $style = self::WEIGHT_NAMES[$weight] ?? (string) $weight;
 
         if ($italic) {
@@ -94,11 +104,47 @@ class GoogleFonts
     }
 
     /**
-     * Rewrite the theme's `font-family` value in a config file's contents.
-     * Returns null when no `font-family` key was found to replace.
+     * Rewrite the app-wide default font in a config file's contents — the
+     * `default` alias of the top-level `fonts` block, falling back to a
+     * legacy theme `font-family` token. Returns null when neither exists.
+     * Line-start anchors keep the docblock example above the fonts block
+     * (its lines begin with `|`) from being touched.
      */
     public static function replaceDefaultFontToken(string $config, string $token): ?string
     {
+        // Preferred spelling: 'fonts' => ['default' => '…'].
+        $updated = preg_replace(
+            "/^([ \t]*'fonts'\s*=>\s*\[[^\]]*?'default'\s*=>\s*)'[^']*'/m",
+            "\$1'{$token}'",
+            $config, 1, $replaced,
+        );
+
+        if ($replaced) {
+            return $updated;
+        }
+
+        // A fonts block with no default alias yet (possibly empty) — insert one.
+        $updated = preg_replace(
+            "/^([ \t]*)'fonts'\s*=>\s*\[\s*\]/m",
+            "\$1'fonts' => [\n\$1    'default' => '{$token}',\n\$1]",
+            $config, 1, $replaced,
+        );
+
+        if ($replaced) {
+            return $updated;
+        }
+
+        $updated = preg_replace(
+            "/^([ \t]*)('fonts'\s*=>\s*\[)/m",
+            "\$1\$2\n\$1    'default' => '{$token}',",
+            $config, 1, $replaced,
+        );
+
+        if ($replaced) {
+            return $updated;
+        }
+
+        // Legacy configs predating the fonts block: rewrite font-family in place.
         $updated = preg_replace(
             "/'font-family'\s*=>\s*'[^']*'/",
             "'font-family' => '{$token}'",

--- a/tests/GoogleFontsTest.php
+++ b/tests/GoogleFontsTest.php
@@ -102,9 +102,42 @@ it('strips spaces from multi-word families', function () {
     expect(GoogleFonts::filenameFor('Rock Salt', 400, false))->toBe('RockSalt-Regular.ttf');
 });
 
+it('reads + as a space in family names (css2 URL spelling)', function () {
+    expect(GoogleFonts::familySpec('Archivo+Black', [400], false))->toBe('Archivo+Black');
+    expect(GoogleFonts::filenameFor('Archivo+Black', 400, false))->toBe('ArchivoBlack-Regular.ttf');
+    expect(GoogleFonts::filenameFor('archivo+black', 400, false))->toBe('ArchivoBlack-Regular.ttf');
+});
+
 // ── replaceDefaultFontToken ─────────────────────────────────────────────────
 
-it('rewrites the font-family value in config contents', function () {
+it('rewrites the fonts default alias', function () {
+    $config = "<?php return [\n    'fonts' => [\n        'default' => 'System',\n        'accent' => 'DynaPuff-Regular',\n    ],\n];";
+
+    $updated = GoogleFonts::replaceDefaultFontToken($config, 'Inter-Regular');
+
+    expect($updated)->toContain("'default' => 'Inter-Regular'");
+    expect($updated)->toContain("'accent' => 'DynaPuff-Regular'");
+    expect($updated)->not->toContain("'System'");
+});
+
+it('inserts a default alias into an empty fonts block', function () {
+    $config = "<?php return [\n    'fonts' => [],\n];";
+
+    $updated = GoogleFonts::replaceDefaultFontToken($config, 'Inter-Regular');
+
+    expect($updated)->toContain("'default' => 'Inter-Regular'");
+});
+
+it('inserts a default alias into a fonts block that lacks one', function () {
+    $config = "<?php return [\n    'fonts' => [\n        'accent' => 'DynaPuff-Regular',\n    ],\n];";
+
+    $updated = GoogleFonts::replaceDefaultFontToken($config, 'Inter-Regular');
+
+    expect($updated)->toContain("'default' => 'Inter-Regular'");
+    expect($updated)->toContain("'accent' => 'DynaPuff-Regular'");
+});
+
+it('rewrites a legacy font-family token when no fonts block exists', function () {
     $config = "<?php return ['theme' => ['light' => ['font-family' => 'System']]];";
 
     $updated = GoogleFonts::replaceDefaultFontToken($config, 'Inter-Regular');
@@ -113,7 +146,7 @@ it('rewrites the font-family value in config contents', function () {
     expect($updated)->not->toContain("'System'");
 });
 
-it('returns null when the config has no font-family key', function () {
+it('returns null when the config has neither a fonts block nor font-family', function () {
     expect(GoogleFonts::replaceDefaultFontToken('<?php return [];', 'X'))->toBeNull();
 });
 
@@ -125,5 +158,7 @@ it('matches the shipped config stub', function () {
     $updated = GoogleFonts::replaceDefaultFontToken($stub, 'Lobster-Regular');
 
     expect($updated)->not->toBeNull();
-    expect($updated)->toContain("'font-family' => 'Lobster-Regular'");
+    expect($updated)->toContain("'default' => 'Lobster-Regular'");
+    // The docblock example above the fonts block must not be rewritten.
+    expect($updated)->toContain("'default' => 'Inter-Regular'");
 });


### PR DESCRIPTION
## What

Completes the migration that the semantic-font-aliases work (e182ce5) started and that #16 patched around: the app-wide default font now lives solely in the config's `'fonts' => ['default' => …]` block — the stub no longer ships a theme `'font-family'` token.

- **`GoogleFonts::replaceDefaultFontToken`** targets the `default` alias first: rewrites an existing alias, inserts one into an empty or alias-less `fonts` block, and falls back to a legacy `font-family` token for apps that still carry one (runtime support for the legacy token is unchanged). Line-start anchors keep the docblock example above the fonts block from being rewritten.
- **`native:font --default`** messaging updated to the alias spelling.
- **Bonus fix riding along**: `canonicalFamily()` — css2-style `Archivo+Black` input now resolves as the spaced "Archivo Black" family in specs and filenames.
- Tests updated: the shipped-stub regression guard now asserts the alias rewrite hits the real block and *not* the docblock example.

Verified locally against the real class: rewrite succeeds on the shipped stub, the real block updates, the docblock example survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)