### PR TITLE
add an Accordion Edge Component

### DIFF
--- a/nativephp.json
+++ b/nativephp.json
@@ -428,6 +428,30 @@
             "android_renderer": "com.nativephp.plugins.native_ui.ui.WebviewRenderer",
             "ios_renderer": "NativeUIWebviewRenderer",
             "self_closing": true
+        },
+        {
+            "type": "accordion",
+            "element": "Native\\Mobile\\UI\\Elements\\Accordion",
+            "blade": "Native\\Mobile\\UI\\Components\\Accordion",
+            "android_renderer": "com.nativephp.plugins.native_ui.ui.AccordionRenderer",
+            "ios_renderer": "NativeUIAccordionRenderer",
+            "self_closing": false
+        },
+        {
+            "type": "accordion_content",
+            "element": "Native\\Mobile\\UI\\Elements\\AccordionContent",
+            "blade": "Native\\Mobile\\UI\\Components\\AccordionContent",
+            "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
+            "ios_renderer": "NativeUIEmptyRenderer",
+            "self_closing": false
+        },
+        {
+            "type": "accordion_header",
+            "element": "Native\\Mobile\\UI\\Elements\\AccordionHeader",
+            "blade": "Native\\Mobile\\UI\\Components\\AccordionHeader",
+            "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
+            "ios_renderer": "NativeUIEmptyRenderer",
+            "self_closing": false
         }
     ],
     "bridge_functions": [

--- a/resources/android/AccordionRenderer.kt
+++ b/resources/android/AccordionRenderer.kt
@@ -1,42 +1,43 @@
 package com.nativephp.plugins.native_ui.ui
 
-import androidx.compose.runtime.Composable
-import com.nativephp.mobile.ui.nativerender.NativeUIBridge
-import com.nativephp.mobile.ui.nativerender.NativeUINode
-import com.nativephp.mobile.ui.nativerender.NodeView
-import com.nativephp.plugins.native_ui.NativeUITheme
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Modifier
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Text
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.animation.animateContentSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.unit.dp
+import com.nativephp.mobile.ui.nativerender.NativeUIBridge
+import com.nativephp.mobile.ui.nativerender.NativeUINode
+import com.nativephp.mobile.ui.nativerender.NodeView
 
 object AccordionRenderer {
     @Composable
     fun Render(node: NativeUINode, modifier: Modifier) {
         val p = node.props
         val serverValue = p.getBool("expanded")
-        val onChangeCb  = p.getCallbackId("on_change")
+        val onChangeCb = p.getCallbackId("on_change")
 
-        var isExpanded by remember { mutableStateOf(p.getBool("expanded")) }
+        // Both keyed on node.id so a recycled node re-seeds from its own
+        // props rather than inheriting the previous occupant's state.
+        var isExpanded by remember(node.id) { mutableStateOf(serverValue) }
         var lastSentValue by remember(node.id) { mutableStateOf(serverValue) }
 
         val rotationAngle by animateFloatAsState(
@@ -45,16 +46,30 @@ object AccordionRenderer {
         )
 
         LaunchedEffect(serverValue) {
+            // Echo-prevention — ignore server pushes that match our last
+            // commit; accept genuine programmatic updates.
             if (serverValue != lastSentValue) {
                 isExpanded = serverValue
                 lastSentValue = serverValue
             }
         }
 
+        // One definition of "the user toggled it", shared by the header row
+        // and the chevron button so either route reports back to PHP.
+        val toggle = {
+            val new = !isExpanded
+            isExpanded = new
+            lastSentValue = new
+            if (onChangeCb != 0) {
+                NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
+            }
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .animateContentSize().then(modifier)
+                .animateContentSize()
+                .then(modifier)
         ) {
             Row(
                 modifier = Modifier
@@ -62,31 +77,27 @@ object AccordionRenderer {
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null
-                    ) {
-                        val new = !isExpanded
-                        isExpanded = new
-                        lastSentValue = new
-                        if (onChangeCb != 0) {
-                            NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
-                        }
-                    },
-                horizontalArrangement = Arrangement.SpaceBetween
+                    ) { toggle() },
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                node.children.forEach { child ->
-                    if (child.type == "accordion_header") {
-                        child.children.forEach { child1 -> NodeView(node = child1) }
+                // Weighted so the header can never crowd the chevron out of
+                // the row: a `<row>` header defaults to STRETCH alignment and
+                // therefore fillMaxWidth, which would otherwise take the lot.
+                Row(
+                    modifier = Modifier.weight(1f, fill = false),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    node.children.forEach { child ->
+                        if (child.type == "accordion_header") {
+                            child.children.forEach { child1 -> NodeView(node = child1) }
+                        }
                     }
                 }
 
-                IconButton(modifier = Modifier.then(Modifier.size(24.dp)),
-                    onClick = {
-                        val new = !isExpanded
-                        isExpanded = new
-                        lastSentValue = new
-                        if (onChangeCb != 0) {
-                            NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
-                        }
-                    }
+                IconButton(
+                    modifier = Modifier.size(24.dp),
+                    onClick = { toggle() }
                 ) {
                     Icon(
                         imageVector = Icons.Default.KeyboardArrowDown,
@@ -97,9 +108,14 @@ object AccordionRenderer {
             }
 
             AnimatedVisibility(visible = isExpanded) {
-                node.children.forEach { child ->
-                    if (child.type == "accordion_content") {
-                        child.children.forEach { child1 -> NodeView(node = child1) }
+                // Column, not a bare lambda: AnimatedVisibility lays its
+                // content out in a Box, so multiple content children would
+                // otherwise stack on top of each other.
+                Column {
+                    node.children.forEach { child ->
+                        if (child.type == "accordion_content") {
+                            child.children.forEach { child1 -> NodeView(node = child1) }
+                        }
                     }
                 }
             }

--- a/resources/android/AccordionRenderer.kt
+++ b/resources/android/AccordionRenderer.kt
@@ -1,0 +1,80 @@
+package com.nativephp.plugins.native_ui.ui
+
+import androidx.compose.runtime.Composable
+import com.nativephp.mobile.ui.nativerender.NativeUINode
+import com.nativephp.mobile.ui.nativerender.NodeView
+import com.nativephp.plugins.native_ui.NativeUITheme
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.animation.animateContentSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.ui.draw.rotate
+
+object AccordionRenderer {
+    @Composable
+    fun Render(node: NativeUINode, modifier: Modifier) {
+        var expanded by remember { mutableStateOf(node.props.getBool("expanded")) }
+        val rotationAngle by animateFloatAsState(
+            targetValue = if (expanded) 180f else 0f,
+            label = "Chevron Rotation"
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .animateContentSize().then(modifier)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) { expanded = !expanded },
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                node.children.forEach { child ->
+                    if (child.type == "accordion_header") {
+                        child.children.forEach { child1 -> NodeView(node = child1) }
+                    }
+                }
+
+                IconButton(modifier = Modifier.then(Modifier.size(24.dp)), onClick = { expanded = !expanded }) {
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowDown,
+                        contentDescription = null,
+                        modifier = Modifier.rotate(rotationAngle),
+                    )
+                }
+            }
+
+            AnimatedVisibility(visible = expanded) {
+                node.children.forEach { child ->
+                    if (child.type == "accordion_content") {
+                        child.children.forEach { child1 -> NodeView(node = child1) }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/resources/android/AccordionRenderer.kt
+++ b/resources/android/AccordionRenderer.kt
@@ -1,6 +1,7 @@
 package com.nativephp.plugins.native_ui.ui
 
 import androidx.compose.runtime.Composable
+import com.nativephp.mobile.ui.nativerender.NativeUIBridge
 import com.nativephp.mobile.ui.nativerender.NativeUINode
 import com.nativephp.mobile.ui.nativerender.NodeView
 import com.nativephp.plugins.native_ui.NativeUITheme
@@ -20,10 +21,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.padding
 import androidx.compose.animation.animateContentSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
@@ -33,11 +32,24 @@ import androidx.compose.ui.draw.rotate
 object AccordionRenderer {
     @Composable
     fun Render(node: NativeUINode, modifier: Modifier) {
-        var expanded by remember { mutableStateOf(node.props.getBool("expanded")) }
+        val p = node.props
+        val serverValue = p.getBool("expanded")
+        val onChangeCb  = p.getCallbackId("on_change")
+
+        var isExpanded by remember { mutableStateOf(p.getBool("expanded")) }
+        var lastSentValue by remember(node.id) { mutableStateOf(serverValue) }
+
         val rotationAngle by animateFloatAsState(
-            targetValue = if (expanded) 180f else 0f,
+            targetValue = if (isExpanded) 180f else 0f,
             label = "Chevron Rotation"
         )
+
+        LaunchedEffect(serverValue) {
+            if (serverValue != lastSentValue) {
+                isExpanded = serverValue
+                lastSentValue = serverValue
+            }
+        }
 
         Column(
             modifier = Modifier
@@ -50,7 +62,14 @@ object AccordionRenderer {
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null
-                    ) { expanded = !expanded },
+                    ) {
+                        val new = !isExpanded
+                        isExpanded = new
+                        lastSentValue = new
+                        if (onChangeCb != 0) {
+                            NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
+                        }
+                    },
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 node.children.forEach { child ->
@@ -59,7 +78,16 @@ object AccordionRenderer {
                     }
                 }
 
-                IconButton(modifier = Modifier.then(Modifier.size(24.dp)), onClick = { expanded = !expanded }) {
+                IconButton(modifier = Modifier.then(Modifier.size(24.dp)),
+                    onClick = {
+                        val new = !isExpanded
+                        isExpanded = new
+                        lastSentValue = new
+                        if (onChangeCb != 0) {
+                            NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
+                        }
+                    }
+                ) {
                     Icon(
                         imageVector = Icons.Default.KeyboardArrowDown,
                         contentDescription = null,
@@ -68,7 +96,7 @@ object AccordionRenderer {
                 }
             }
 
-            AnimatedVisibility(visible = expanded) {
+            AnimatedVisibility(visible = isExpanded) {
                 node.children.forEach { child ->
                     if (child.type == "accordion_content") {
                         child.children.forEach { child1 -> NodeView(node = child1) }

--- a/resources/ios/NativeUIAccordionRenderer.swift
+++ b/resources/ios/NativeUIAccordionRenderer.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct NativeUIAccordionRenderer: View {
+    let node: NativeUINode
+    @State private var isExpanded: Bool = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        DisclosureGroup(
+            isExpanded: $isExpanded,
+            content: {
+                ForEach(node.children) { child in
+                    if child.type == "accordion_content" {
+                        ForEach(child.children) { child1 in
+                            NodeView(node: child1)
+                                .equatable()
+                        }
+                        
+                    }
+                }
+            },
+            label: {
+                ForEach(node.children) { child in
+                    if child.type == "accordion_header" {
+                        ForEach(child.children) { child1 in
+                            NodeView(node: child1)
+                                .equatable()
+                        }
+                    }
+                }
+            }
+        )
+        .onAppear {
+            isExpanded = node.props.getBool("expanded")
+        }
+    }
+}

--- a/resources/ios/NativeUIAccordionRenderer.swift
+++ b/resources/ios/NativeUIAccordionRenderer.swift
@@ -1,20 +1,41 @@
 import SwiftUI
 
+/// SwiftUI DisclosureGroup renderer.
+///
+/// Expand/collapse with echo-prevention value sync (the same contract
+/// `NativeUIToggleRenderer` uses): `expanded` is a live binding, not just a
+/// mount-time hint, so PHP can drive the group open or closed at any point.
 struct NativeUIAccordionRenderer: View {
     let node: NativeUINode
+
     @State private var isExpanded: Bool = false
     @State private var lastSentValue: Bool = false
     @State private var initialized: Bool = false
-    
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         let p = node.props
         let serverValue = p.getBool("expanded")
         let onChangeCb  = p.getCallbackId("on_change")
 
+        // Every *user-driven* change flows through this binding — the
+        // disclosure chevron and the label tap both land in the setter — so
+        // PHP hears about each one. Server-driven updates assign `isExpanded`
+        // directly (see `.onChange(of: serverValue)`) and deliberately bypass
+        // it, so adopting a programmatic value never echoes an event back.
+        let expanded = Binding<Bool>(
+            get: { isExpanded },
+            set: { new in
+                guard new != isExpanded else { return }
+                isExpanded = new
+                lastSentValue = new
+                if onChangeCb != 0 {
+                    NativeElementBridge.sendToggleChangeEvent(onChangeCb, nodeId: node.id, value: new)
+                }
+            }
+        )
+
         DisclosureGroup(
-            isExpanded: $isExpanded,
+            isExpanded: expanded,
             content: {
                 ForEach(node.children) { child in
                     if child.type == "accordion_content" {
@@ -38,14 +59,7 @@ struct NativeUIAccordionRenderer: View {
                 }
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    withAnimation {
-                        let new = !isExpanded
-                        isExpanded = new
-                        lastSentValue = new
-                        if onChangeCb != 0 {
-                            NativeElementBridge.sendToggleChangeEvent(onChangeCb, nodeId: node.id, value: new)
-                        }
-                    }
+                    withAnimation { expanded.wrappedValue.toggle() }
                 }
             }
         )
@@ -54,6 +68,16 @@ struct NativeUIAccordionRenderer: View {
                 isExpanded = serverValue
                 lastSentValue = serverValue
                 initialized = true
+            }
+        }
+        .onChange(of: serverValue) { _, new in
+            // Echo-prevention — ignore server pushes that match our last
+            // commit; accept genuine programmatic updates. Without this the
+            // group only ever reads `expanded` once, so "expand all" and
+            // friends silently do nothing on iOS.
+            if new != lastSentValue {
+                withAnimation { isExpanded = new }
+                lastSentValue = new
             }
         }
     }

--- a/resources/ios/NativeUIAccordionRenderer.swift
+++ b/resources/ios/NativeUIAccordionRenderer.swift
@@ -3,9 +3,16 @@ import SwiftUI
 struct NativeUIAccordionRenderer: View {
     let node: NativeUINode
     @State private var isExpanded: Bool = false
+    @State private var lastSentValue: Bool = false
+    @State private var initialized: Bool = false
+    
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
+        let p = node.props
+        let serverValue = p.getBool("expanded")
+        let onChangeCb  = p.getCallbackId("on_change")
+
         DisclosureGroup(
             isExpanded: $isExpanded,
             content: {
@@ -15,23 +22,39 @@ struct NativeUIAccordionRenderer: View {
                             NodeView(node: child1)
                                 .equatable()
                         }
-                        
                     }
                 }
             },
             label: {
-                ForEach(node.children) { child in
-                    if child.type == "accordion_header" {
-                        ForEach(child.children) { child1 in
-                            NodeView(node: child1)
-                                .equatable()
+                HStack {
+                    ForEach(node.children) { child in
+                        if child.type == "accordion_header" {
+                            ForEach(child.children) { child1 in
+                                NodeView(node: child1)
+                                    .equatable()
+                            }
+                        }
+                    }
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation {
+                        let new = !isExpanded
+                        isExpanded = new
+                        lastSentValue = new
+                        if onChangeCb != 0 {
+                            NativeElementBridge.sendToggleChangeEvent(onChangeCb, nodeId: node.id, value: new)
                         }
                     }
                 }
             }
         )
         .onAppear {
-            isExpanded = node.props.getBool("expanded")
+            if !initialized {
+                isExpanded = serverValue
+                lastSentValue = serverValue
+                initialized = true
+            }
         }
     }
 }

--- a/src/Components/Accordion.php
+++ b/src/Components/Accordion.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Native\Mobile\UI\Components;
+
+use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
+
+class Accordion extends NativeBladeComponent
+{
+    protected bool $isSelfClosing = false;
+
+    protected function elementType(): string
+    {
+        return 'accordion';
+    }
+}

--- a/src/Components/AccordionContent.php
+++ b/src/Components/AccordionContent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Native\Mobile\UI\Components;
+
+use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
+
+class AccordionContent extends NativeBladeComponent
+{
+    protected bool $isSelfClosing = false;
+
+    protected function elementType(): string
+    {
+        return 'accordion_content';
+    }
+}

--- a/src/Components/AccordionHeader.php
+++ b/src/Components/AccordionHeader.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Native\Mobile\UI\Components;
+
+use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
+
+class AccordionHeader extends NativeBladeComponent
+{
+    protected bool $isSelfClosing = false;
+
+    protected function elementType(): string
+    {
+        return 'accordion_header';
+    }
+}

--- a/src/Elements/Accordion.php
+++ b/src/Elements/Accordion.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Native\Mobile\UI\Elements;
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+
+class Accordion extends Element
+{
+    protected string $type = 'accordion';
+
+    protected array $props = [];
+
+    public static function make(Element ...$children): static
+    {
+        $el = new static;
+        $el->children = $children;
+
+        return $el;
+    }
+
+    public function applyAttributes(array $attrs): void
+    {
+        if (isset($attrs['expanded'])) {
+            $this->expanded((bool) $attrs['expanded']);
+        }
+
+        $this->applyA11yAttributes($attrs);
+    }
+
+    public function expanded(bool $expanded): static
+    {
+        $this->props['expanded'] = $expanded;
+
+        return $this;
+    }
+
+    protected function resolveProps(CallbackRegistry $registry): array
+    {
+        return $this->props;
+    }
+}

--- a/src/Elements/Accordion.php
+++ b/src/Elements/Accordion.php
@@ -11,6 +11,8 @@ class Accordion extends Element
 
     protected array $props = [];
 
+    protected ?string $changeCallback = null;
+
     public static function make(Element ...$children): static
     {
         $el = new static;
@@ -35,8 +37,21 @@ class Accordion extends Element
         return $this;
     }
 
+    public function onChange(string $method): static
+    {
+        $this->changeCallback = $method;
+
+        return $this;
+    }
+
     protected function resolveProps(CallbackRegistry $registry): array
     {
-        return $this->props;
+        $props = $this->props;
+
+        if ($this->changeCallback !== null) {
+            $props['on_change'] = $registry->register($this->changeCallback);
+        }
+
+        return $props;
     }
 }

--- a/src/Elements/AccordionContent.php
+++ b/src/Elements/AccordionContent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Native\Mobile\UI\Elements;
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+
+class AccordionContent extends Element
+{
+    protected string $type = 'accordion_content';
+
+    protected array $props = [];
+
+    public static function make(Element ...$children): static
+    {
+        $el = new static;
+        $el->children = $children;
+
+        return $el;
+    }
+
+    public function applyAttributes(array $attrs): void
+    {
+        $this->applyA11yAttributes($attrs);
+    }
+
+    protected function resolveProps(CallbackRegistry $registry): array
+    {
+        return $this->props;
+    }
+}

--- a/src/Elements/AccordionHeader.php
+++ b/src/Elements/AccordionHeader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Native\Mobile\UI\Elements;
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+
+class AccordionHeader extends Element
+{
+    protected string $type = 'accordion_header';
+
+    protected array $props = [];
+
+    public static function make(Element ...$children): static
+    {
+        $el = new static;
+        $el->children = $children;
+
+        return $el;
+    }
+
+    public function applyAttributes(array $attrs): void
+    {
+        $this->applyA11yAttributes($attrs);
+    }
+
+    protected function resolveProps(CallbackRegistry $registry): array
+    {
+        return $this->props;
+    }
+}

--- a/tests/CollectorElementsTest.php
+++ b/tests/CollectorElementsTest.php
@@ -7,6 +7,9 @@ use Native\Mobile\Edge\Elements\Row;
 use Native\Mobile\Edge\Elements\Text;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\TailwindParser;
+use Native\Mobile\UI\Elements\Accordion;
+use Native\Mobile\UI\Elements\AccordionContent;
+use Native\Mobile\UI\Elements\AccordionHeader;
 use Native\Mobile\UI\Elements\BareTextInput;
 use Native\Mobile\UI\Elements\Button;
 use Native\Mobile\UI\Elements\Checkbox;
@@ -33,6 +36,9 @@ beforeEach(function () {
     ElementRegistry::register('progress_bar', ProgressBar::class);
     ElementRegistry::register('radio_group', RadioGroup::class);
     ElementRegistry::register('radio', Radio::class);
+    ElementRegistry::register('accordion', Accordion::class);
+    ElementRegistry::register('accordion_header', AccordionHeader::class);
+    ElementRegistry::register('accordion_content', AccordionContent::class);
 });
 
 afterEach(function () {
@@ -174,6 +180,50 @@ it('applies radio group and radio props', function () {
     expect($tree['children'][0]['props']['value'])->toBe('opt1');
     expect($tree['children'][0]['props']['label'])->toBe('Option 1');
     expect($tree['children'][2]['props']['disabled'])->toBeTrue();
+});
+
+it('applies accordion props and keeps header and content as distinct slots', function () {
+    NativeElementCollector::open('accordion', ['expanded' => true, '_change' => 'onToggleSection']);
+    NativeElementCollector::open('accordion_header', []);
+    NativeElementCollector::leaf('text', ['text' => 'Specifications']);
+    NativeElementCollector::close();
+    NativeElementCollector::open('accordion_content', []);
+    NativeElementCollector::leaf('text', ['text' => 'Weight — 1.24 kg']);
+    NativeElementCollector::close();
+    NativeElementCollector::close();
+
+    $registry = new CallbackRegistry;
+    $tree = NativeElementCollector::collect()->toArray($registry);
+
+    expect($tree['type'])->toBe('accordion');
+    expect($tree['props']['expanded'])->toBeTrue();
+    expect($registry->resolve($tree['props']['on_change']))->toBe(['method' => 'onToggleSection', 'args' => []]);
+
+    // Both renderers pick their slot by child type, so the two must stay
+    // separate typed children rather than being flattened into one list.
+    expect($tree['children'])->toHaveCount(2);
+    expect($tree['children'][0]['type'])->toBe('accordion_header');
+    expect($tree['children'][0]['children'][0]['props']['text'])->toBe('Specifications');
+    expect($tree['children'][1]['type'])->toBe('accordion_content');
+    expect($tree['children'][1]['children'][0]['props']['text'])->toBe('Weight — 1.24 kg');
+});
+
+it('defaults an accordion to collapsed with no change callback', function () {
+    NativeElementCollector::open('accordion', []);
+    NativeElementCollector::open('accordion_header', []);
+    NativeElementCollector::leaf('text', ['text' => 'Care instructions']);
+    NativeElementCollector::close();
+    NativeElementCollector::close();
+
+    $registry = new CallbackRegistry;
+    $tree = NativeElementCollector::collect()->toArray($registry);
+
+    // An untouched accordion carries no props at all — the renderers read
+    // `expanded` as false and `on_change` as callback id 0.
+    $props = $tree['props'] ?? [];
+
+    expect($props)->not->toHaveKey('on_change');
+    expect($props['expanded'] ?? false)->toBeFalse();
 });
 
 it('produces identical tree to programmatic API', function () {


### PR DESCRIPTION
This creates an easy to use Accordion Edge Component that works like most accordions people are used to on the web.

Example syntax:

```
<accordion expanded="true" class="p-5 bg-gray-100 rounded-2xl">
    <accordion-header>
        <column>
            <text class="text-[#0000ff]">Test Accordion2</text>
        </column>
    </accordion-header>
    <accordion-content>
        <column class="pt-5">
            <text class="text-xs uppercase font-semibold text-theme-on-surface-variant">Variants2</text>
            <text class="text-xs uppercase font-semibold text-theme-on-surface-variant">asdf adfsadfs adfs 2</text>
            <image src="https://picsum.photos/seed/nativephp/400/200" class="w-full h-[200] mt-4 rounded-xl" :fit="2" />
        </column>
    </accordion-content>
</accordion>
```

This is my first time doing all of this, so please let me know what else you might need me to do.

Android screenshot:
<img width="864" height="1075" alt="Screenshot_20260724-160122" src="https://github.com/user-attachments/assets/ea690589-81b5-4555-b294-b57f7bbcfd91" />

iOS screenshot:
<img width="1320" height="1347" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-24 at 16 06 35" src="https://github.com/user-attachments/assets/bff676d7-5411-4aef-a83a-1f7d8c32b227" />
