### PR TITLE
Honor negative insets on absolute stack children

### DIFF
--- a/resources/android/ContainerRenderers.kt
+++ b/resources/android/ContainerRenderers.kt
@@ -79,21 +79,23 @@ object StackRenderer {
                     // Absolute children pin to the stack's edges by inset —
                     // the docs-blessed "layer a badge over an icon" pattern.
                     // Same anchor convention as ComposeFlexLayout / the iOS
-                    // FlexContainer: a positive right/bottom inset anchors to
-                    // that edge; otherwise offset from top-left.
+                    // FlexContainer: a NON-ZERO right/bottom inset anchors to
+                    // that edge; otherwise offset from top-left. Non-zero (not
+                    // positive) so NEGATIVE insets overhang the edge, matching
+                    // Tailwind's `-right-8` bleed.
                     if (layout.positionType == PositionType.ABSOLUTE) {
                         val left = layout.positionLeft
                         val top = layout.positionTop
                         val right = layout.positionRight
                         val bottom = layout.positionBottom
                         val anchor = when {
-                            right > 0f && bottom > 0f -> Alignment.BottomEnd
-                            right > 0f                -> Alignment.TopEnd
-                            bottom > 0f               -> Alignment.BottomStart
-                            else                      -> Alignment.TopStart
+                            right != 0f && bottom != 0f -> Alignment.BottomEnd
+                            right != 0f                 -> Alignment.TopEnd
+                            bottom != 0f                -> Alignment.BottomStart
+                            else                        -> Alignment.TopStart
                         }
-                        val offsetX = if (right > 0f) (-right).dp else left.dp
-                        val offsetY = if (bottom > 0f) (-bottom).dp else top.dp
+                        val offsetX = if (right != 0f) (-right).dp else left.dp
+                        val offsetY = if (bottom != 0f) (-bottom).dp else top.dp
                         childMod = childMod.align(anchor).offset(x = offsetX, y = offsetY)
                     }
                 }

--- a/resources/ios/NativeUIStackRenderer.swift
+++ b/resources/ios/NativeUIStackRenderer.swift
@@ -74,8 +74,9 @@ struct NativeUIStackLayout: Layout {
 
             // Absolute children pin to the stack's edges by inset — the
             // docs-blessed "layer a badge over an icon" pattern. Same anchor
-            // convention as FlexContainer.placeAbsolute: a positive right /
-            // bottom inset (with zero left/top) anchors to that edge.
+            // convention as FlexContainer.placeAbsolute: a NON-ZERO right /
+            // bottom inset (with zero left/top) anchors to that edge, and a
+            // negative one deliberately overhangs it (`-right-8` bleed).
             if layout?.positionType == PositionType.absolute {
                 let top = CGFloat(layout?.positionTop ?? 0)
                 let right = CGFloat(layout?.positionRight ?? 0)
@@ -83,11 +84,11 @@ struct NativeUIStackLayout: Layout {
                 let left = CGFloat(layout?.positionLeft ?? 0)
 
                 var x = bounds.minX + left
-                if right > 0 && left == 0 {
+                if right != 0 && left == 0 {
                     x = bounds.maxX - width - right
                 }
                 var y = bounds.minY + top
-                if bottom > 0 && top == 0 {
+                if bottom != 0 && top == 0 {
                     y = bounds.maxY - height - bottom
                 }
 


### PR DESCRIPTION
## Problem

`<native:stack>`'s absolute placement used a **positive** inset as the only signal for "anchored to this edge":

```swift
if right > 0 && left == 0 {
    x = bounds.maxX - width - right
}
```

So a negative inset couldn't be expressed at all — which rules out the bleed pattern of parking an oversized decorative icon (a trophy, a watermark) so it overhangs the container, the direct equivalent of Tailwind's `-right-8`.

## Change

Both placement sites select the trailing anchor on `right != 0` instead of `right > 0`:

- `resources/ios/NativeUIStackRenderer.swift` — `-right-8` resolves to `maxX - width + 32`
- `resources/android/ContainerRenderers.kt` — same, via `Alignment.TopEnd` + a positive `offset`

Zero still means "no anchor on that edge."

## Pairs with NativePHP/mobile-air#230

That PR teaches `TailwindParser` to read the leading `-` in the first place. **Neither half is useful alone** — without the parser, `-right-8` never parses; without this, it parses and is then ignored. Landing them together is the intent.

The same one-line change lands in core's `FlexContainer.placeAbsolute` and `ComposeFlexLayout` in that PR, so all four placement sites keep the identical convention.

## Known limitation, documented at both call sites

`right-0` still reads as "no right anchor" and falls through to the leading edge. Distinguishing an unset edge from an explicit zero needs a spare field, and the packed 160-byte node struct is full (props start at byte 154) — a stride bump across the encoder and both decoders is out of scope here. Pre-existing behavior, unchanged.

## Testing

No PHP surface to unit-test — this is renderer-only. Verified on the iOS simulator: an 88pt `<native:icon>` with `class="absolute top-0 -right-8"` inside a `<native:stack>` now overhangs the card's trailing edge, where previously it either sat inside the edge (positive inset) or jumped to the leading edge (`right-0`).