### PR TITLE
Drop Edge-bridge references, honor negative insets, fix stack measurement

### DIFF
--- a/resources/android/ContainerRenderers.kt
+++ b/resources/android/ContainerRenderers.kt
@@ -79,21 +79,23 @@ object StackRenderer {
                     // Absolute children pin to the stack's edges by inset —
                     // the docs-blessed "layer a badge over an icon" pattern.
                     // Same anchor convention as ComposeFlexLayout / the iOS
-                    // FlexContainer: a positive right/bottom inset anchors to
-                    // that edge; otherwise offset from top-left.
+                    // FlexContainer: a NON-ZERO right/bottom inset anchors to
+                    // that edge; otherwise offset from top-left. Non-zero (not
+                    // positive) so NEGATIVE insets overhang the edge, matching
+                    // Tailwind's `-right-8` bleed.
                     if (layout.positionType == PositionType.ABSOLUTE) {
                         val left = layout.positionLeft
                         val top = layout.positionTop
                         val right = layout.positionRight
                         val bottom = layout.positionBottom
                         val anchor = when {
-                            right > 0f && bottom > 0f -> Alignment.BottomEnd
-                            right > 0f                -> Alignment.TopEnd
-                            bottom > 0f               -> Alignment.BottomStart
-                            else                      -> Alignment.TopStart
+                            right != 0f && bottom != 0f -> Alignment.BottomEnd
+                            right != 0f                 -> Alignment.TopEnd
+                            bottom != 0f                -> Alignment.BottomStart
+                            else                        -> Alignment.TopStart
                         }
-                        val offsetX = if (right > 0f) (-right).dp else left.dp
-                        val offsetY = if (bottom > 0f) (-bottom).dp else top.dp
+                        val offsetX = if (right != 0f) (-right).dp else left.dp
+                        val offsetY = if (bottom != 0f) (-bottom).dp else top.dp
                         childMod = childMod.align(anchor).offset(x = offsetX, y = offsetY)
                     }
                 }

--- a/resources/android/NavRenderers.kt
+++ b/resources/android/NavRenderers.kt
@@ -37,11 +37,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nativephp.mobile.R
-import com.nativephp.mobile.ui.NativeUIState
 import com.nativephp.mobile.ui.getIconName
 import com.nativephp.mobile.ui.nativerender.LocalSafeAreaBottom
 import com.nativephp.mobile.ui.nativerender.LocalSafeAreaTop
-import com.nativephp.mobile.ui.nativerender.NativeEdgeDrawerState
 import com.nativephp.mobile.ui.nativerender.NativeElementBridge
 import com.nativephp.mobile.ui.nativerender.NativeUINode
 import kotlinx.coroutines.launch
@@ -257,7 +255,12 @@ object BottomNavRenderer {
 object SideNavRenderer {
     @Composable
     fun Render(node: NativeUINode, modifier: Modifier) {
-        NativeEdgeDrawerState.sideNavNode.value = node
+        // No-op: the Edge-bridge drawer host (NativeEdgeDrawerState) was
+        // removed with the v3 Edge chrome system. A hoisted side_nav node
+        // currently has no drawer host on Android — layout drawers go
+        // through HasLayoutDrawer / the native_drawer root host instead.
+        // This renderer stays registered so a side_nav in the wire tree
+        // renders nothing rather than crashing renderer dispatch.
     }
 }
 

--- a/resources/ios/NativeUIStackRenderer.swift
+++ b/resources/ios/NativeUIStackRenderer.swift
@@ -68,14 +68,27 @@ struct NativeUIStackLayout: Layout {
             let widthFill = layout?.widthMode == SizeMode.fill
             let heightFill = layout?.heightMode == SizeMode.fill
 
-            let natural = subview.sizeThatFits(.unspecified)
+            // Measure against the width the child will ACTUALLY be given. A
+            // `w-full` child's height depends on that width — wrapping text is
+            // the obvious case — and `.unspecified` measures at unbounded
+            // width, so a multi-line title reports the height of ONE long line.
+            // That under-reported height then feeds the bottom-anchored
+            // placement below (`maxY - height - bottom`), putting the child far
+            // too low and letting it spill out of the stack once it renders
+            // wrapped. Non-filling children keep the unspecified proposal, so
+            // intrinsic-sized badges and chips are unaffected.
+            let natural = subview.sizeThatFits(ProposedViewSize(
+                width: widthFill ? bounds.width : nil,
+                height: heightFill ? bounds.height : nil
+            ))
             let width = widthFill ? bounds.width : natural.width
             let height = heightFill ? bounds.height : natural.height
 
             // Absolute children pin to the stack's edges by inset — the
             // docs-blessed "layer a badge over an icon" pattern. Same anchor
-            // convention as FlexContainer.placeAbsolute: a positive right /
-            // bottom inset (with zero left/top) anchors to that edge.
+            // convention as FlexContainer.placeAbsolute: a NON-ZERO right /
+            // bottom inset (with zero left/top) anchors to that edge, and a
+            // negative one deliberately overhangs it (`-right-8` bleed).
             if layout?.positionType == PositionType.absolute {
                 let top = CGFloat(layout?.positionTop ?? 0)
                 let right = CGFloat(layout?.positionRight ?? 0)
@@ -83,11 +96,11 @@ struct NativeUIStackLayout: Layout {
                 let left = CGFloat(layout?.positionLeft ?? 0)
 
                 var x = bounds.minX + left
-                if right > 0 && left == 0 {
+                if right != 0 && left == 0 {
                     x = bounds.maxX - width - right
                 }
                 var y = bounds.minY + top
-                if bottom > 0 && top == 0 {
+                if bottom != 0 && top == 0 {
                     y = bounds.maxY - height - bottom
                 }
 


### PR DESCRIPTION
Three changes to the stack/chrome layer.

**Drop references to the deleted Edge-bridge chrome classes.** Follows the removal of the Gen-B Edge bridge chrome system in NativePHP/mobile-air#227 — this PR does not compile against a `mobile` that still has those classes, so **#227 must merge first**.

**Honor negative insets on absolute stack children.** Anchor selection tested `> 0`, so a negative inset fell through to the top-left branch instead of anchoring trailing/bottom and overhanging it. Now tests `!= 0`, matching `ComposeFlexLayout` and the iOS `FlexContainer`. Zero still means "no anchor on that edge". Overlaps in intent with #21.

**Measure filling stack children against the width they actually get.** `NativeUIStackLayout.placeSubviews` measured every child with `sizeThatFits(.unspecified)` — unbounded width — and then used that height to place it. For a `w-full` child whose height depends on its width, that is wrong: wrapping text reports the height of a single long line.

Bottom-anchored placement computes `maxY - height - bottom`, so the under-reported height placed the child far too low and it spilled out of the stack once it rendered wrapped at the real width. The symptom that surfaced it was a five-line title overlaid on a card poster escaping the card and covering the buttons beneath it.

Filling children are now measured against `bounds`; non-filling children keep the unspecified proposal, so intrinsic-sized badges and chips are unaffected. Android was never affected — Compose `Box` + `align` measures against real constraints.

## Testing

No automated coverage: these are Swift/Kotlin renderer changes, and the package's suite is PHP-only. Verified by building an app whose show card overlays a wrapping title on a bottom-anchored scrim — the title now sizes and sits inside the poster instead of overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)