### PR TITLE
review(#18): align the @selectionChange contract across iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,37 @@ OutlinedTextInput::make()
     ->selectionDebounceMs(100);
 ```
 
-Events are coalesced on the native side — by default at most one every **50ms**
+Events are coalesced on the native side — by default at most one every **150ms**
 while the caret moves (the trailing position always fires). Tune the window per
 input with `selection-debounce-ms` / `selectionDebounceMs` (fluent:
 `->selectionDebounceMs()`); when unset, nothing is serialized and the renderer
-default of 50ms applies.
+default applies. A value of `0` (or less) also means "use the default"; positive
+values are floored at one frame (16ms).
 
-`@selectionChange` is never emitted for `secure` inputs — the renderers
-suppress it so caret telemetry can't leak password-field context.
+> **Every event carries the full current text**, and every event costs a bridge
+> frame plus a full component re-render. That is independent of the
+> `native:model` sync mode: pairing `@selectionChange` with `native:model.blur`
+> or `.debounce` still ships the field contents to PHP on the selection
+> cadence, not the model cadence. Budget the debounce window accordingly.
+
+`@selectionChange` is never emitted for `secure` inputs. The callback is not
+serialized at all when `secure` is set, and both renderers additionally refuse
+to emit — so caret telemetry can't leak password-field context.
+
+### Contract details
+
+- **Programmatic value pushes.** When PHP pushes a new `value` onto the input,
+  the field is replaced wholesale and the caret drops at the end. Both platforms
+  report that immediately as a single `(text, length, length)` event, bypassing
+  the debounce. A handler that rewrites the bound model will therefore see one
+  follow-up event.
+- **Discontiguous selections** (multi-range, iOS) are reported as a single span
+  from the lowest start to the highest end — the reported range covers the gaps,
+  so `mb_substr($text, $start, $end - $start)` includes text the user did not
+  select.
+- **`read-only` inputs** report selection on Android (which keeps them focusable
+  for copy) but not on iOS (where read-only implies disabled, so the field never
+  focuses).
 
 A typical use is typeahead / mention triggers, where `@change` alone can't tell
 you *where* the user is typing:

--- a/resources/android/TextInputShared.kt
+++ b/resources/android/TextInputShared.kt
@@ -130,9 +130,30 @@ internal fun parseTextInputProps(node: NativeUINode): TextInputProps {
         onSelectionChangeCb = p.getCallbackId("on_selection_change"),
         syncMode     = parseSyncMode(p.getString("sync_mode", "live")),
         debounceMs   = p.getInt("debounce_ms").let { if (it > 0) it else 300 },
-        selectionDebounceMs = p.getInt("selection_debounce_ms").let { if (it > 0) it else 50 },
+        selectionDebounceMs = resolveSelectionDebounceMs(p.getInt("selection_debounce_ms")),
     )
 }
+
+/**
+ * Resolve `selection_debounce_ms` to an effective window. PHP only serializes
+ * the prop when explicitly configured, so an absent prop and an explicit `0`
+ * are indistinguishable here — both mean "use the default".
+ *
+ * Positive values are floored at one frame: every emission costs a bridge
+ * frame plus a full PHP component re-render, so a sub-frame window buys
+ * nothing and can saturate the bridge while the caret is dragged.
+ *
+ * iOS resolves the same prop identically ([NativeUITextInputCore.swift]) —
+ * keep the two in sync.
+ */
+internal fun resolveSelectionDebounceMs(raw: Int): Int =
+    if (raw > 0) raw.coerceAtLeast(NUI_SELECTION_DEBOUNCE_FLOOR_MS) else NUI_SELECTION_DEBOUNCE_DEFAULT_MS
+
+/** Default coalescing window for `@selectionChange`, in ms. */
+internal const val NUI_SELECTION_DEBOUNCE_DEFAULT_MS = 150
+
+/** Lower bound for an explicitly configured window — one frame at 60fps. */
+internal const val NUI_SELECTION_DEBOUNCE_FLOOR_MS = 16
 
 /** String hint → M3 KeyboardType. Unknown falls through to text. */
 internal fun resolveKeyboardType(kind: String): KeyboardType = when (kind.lowercase()) {

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -21,10 +21,13 @@ paths serialize to the same wire tree.
 - Text inputs also take `@selectionChange` for caret / selection reporting:
   the handler is called as `method(string $text, int $selectionStart, int
   $selectionEnd)` with offsets in Unicode code points (`start === end` for a
-  plain caret). Events are coalesced natively (50ms default; tune with
+  plain caret). Events are coalesced natively (150ms default; tune with
   `selection-debounce-ms`). Never fired on `secure` inputs. Use it for
   typeahead / mention triggers where `@change` can't tell you *where* the
   user is typing.
+- Each `@selectionChange` event carries the FULL current text and costs a
+  component re-render, independent of the `native:model` sync mode — don't
+  reach for it when plain `@change` would do.
 
 @verbatim
 <code-snippet name="Declaring native elements in Blade" lang="blade">

--- a/resources/ios/NativeUITextInputCore.swift
+++ b/resources/ios/NativeUITextInputCore.swift
@@ -68,7 +68,12 @@ struct NativeUITextInputCore: View {
         // Selection reporting is opt-in (0/absent ⇒ off) and never applies to
         // secure fields. Read exactly like `on_change` / `debounce_ms` above.
         let onSelectionCb = p.getCallbackId("on_selection_change")
-        let selDebounceMs = p.getInt("selection_debounce_ms", default: 50)
+        // PHP only serializes this prop when explicitly configured, so an
+        // absent prop and an explicit 0 are indistinguishable — both mean
+        // "use the default". Positive values are floored at one frame.
+        // Android resolves the same prop identically (`TextInputShared.kt`) —
+        // keep the two in sync.
+        let selDebounceMs = Self.resolveSelectionDebounceMs(p.getInt("selection_debounce_ms"))
         let selectionEnabled = onSelectionCb != 0 && !secure
         let fontName      = p.getString("font_name")
         let lineSpacing   = NativeUIFontResolver.lineSpacing(
@@ -151,6 +156,18 @@ struct NativeUITextInputCore: View {
             if newServerValue != lastSentValue {
                 text = newServerValue
                 lastSentValue = newServerValue
+                // A programmatic push replaces the field wholesale and drops
+                // the caret at the end. Report that immediately, regardless of
+                // focus — matching the Android renderers, which flush the same
+                // end-caret event from their value-sync effect. Without this,
+                // a handler that rewrites the bound model (the mention-
+                // typeahead case) sees a follow-up event on Android and
+                // nothing on iOS. Emitting here also beats letting the
+                // `.onChange(of: text)` path below fire with the STALE cached
+                // offsets clamped to the new length.
+                if selectionEnabled {
+                    emitServerPushSelection(text: newServerValue, cb: onSelectionCb)
+                }
                 // Send-BUTTON path (no `onSubmit`): a send clears the draft to
                 // empty. Keep the keyboard up by re-asserting focus. Opt-in via
                 // `keep-focus-on-submit`; only on a clear-to-empty so ordinary
@@ -304,12 +321,46 @@ struct NativeUITextInputCore: View {
     ///
     /// Scalar count — NOT grapheme count — so a skin-toned 👍🏽 (2 scalars) or a
     /// combining "e"+◌́ (2 scalars) advances the offset by 2, matching the
-    /// pinned contract. The defensive clamp keeps a momentarily-stale index from
-    /// trapping `distance`; on the normal path it's a no-op.
+    /// pinned contract.
+    ///
+    /// The clamp bounds a momentarily-stale index to `startIndex...endIndex`;
+    /// it does NOT guarantee scalar ALIGNMENT (an index pointing into the
+    /// middle of a multi-byte sequence stays misaligned). Swift rounds rather
+    /// than traps when measuring distance to a misaligned index in the scalar
+    /// view, so the worst case is an off-by-one offset, not a crash. On the
+    /// normal path — indices SwiftUI just derived from this same string — the
+    /// clamp is a no-op.
     private func scalarOffset(of index: String.Index, in string: String) -> Int {
         let scalars = string.unicodeScalars
         let clamped = min(max(index, string.startIndex), string.endIndex)
         return scalars.distance(from: scalars.startIndex, to: clamped)
+    }
+
+    /// Default coalescing window for `@selectionChange`, in ms.
+    private static let selectionDebounceDefaultMs = 150
+
+    /// Lower bound for an explicitly configured window — one frame at 60fps.
+    private static let selectionDebounceFloorMs = 16
+
+    /// Resolve `selection_debounce_ms` to an effective window. `<= 0` (which
+    /// includes "prop absent", since PHP only serializes it when configured)
+    /// means the default; positive values are floored at one frame, because
+    /// every emission costs a bridge frame plus a full PHP component
+    /// re-render.
+    private static func resolveSelectionDebounceMs(_ raw: Int) -> Int {
+        raw > 0 ? max(raw, selectionDebounceFloorMs) : selectionDebounceDefaultMs
+    }
+
+    /// Report an end-of-text caret for a programmatic value push, bypassing
+    /// the debounce. Sets the cached offsets first so the `.onChange(of: text)`
+    /// pass that follows recomputes the identical payload and is dropped by
+    /// the dedupe rather than emitting stale offsets.
+    private func emitServerPushSelection(text pushedText: String, cb: Int) {
+        let count = pushedText.unicodeScalars.count
+        selStart = count
+        selEnd = count
+        pendingSelection = NativeUISelectionPayload(text: pushedText, start: count, end: count)
+        flushSelection(cb: cb)
     }
 
     /// (Re)arm the trailing-edge debounce. Recomputes the payload from the

--- a/src/Elements/BaseTextInput.php
+++ b/src/Elements/BaseTextInput.php
@@ -28,9 +28,10 @@ use Native\Mobile\Icon\IosSymbol;
  * `@selectionChange` reports caret / selection movement: the handler is
  * called with `(string $text, int $selectionStart, int $selectionEnd)`,
  * offsets in Unicode code points (start === end for a bare caret). Events
- * are coalesced on the native side — 50ms by default, tunable per input
+ * are coalesced on the native side — 150ms by default, tunable per input
  * via `selection-debounce-ms` / `->selectionDebounceMs()`. Never emitted
- * for `secure` inputs (renderer-enforced).
+ * for `secure` inputs (the callback is not serialized, and the renderers
+ * refuse to emit as well).
  *
  * Subclasses (`OutlinedTextInput`, `FilledTextInput`) only override `$type`
  * so native renderers can dispatch to the right Material3 / SwiftUI primitive.
@@ -154,12 +155,17 @@ abstract class BaseTextInput extends Element
         }
 
         // `@selectionChange` → `_selectionChange` (precompiler rewrite).
-        // Newer cores wire this through the collector's applyCallbacks
-        // (`method_exists($element, 'onSelectionChange')`), but cores that
-        // predate the `text_selection` callback kind pass the attr through
-        // untouched — applyAttributes always receives the full attr set, so
-        // guard here too. Double-wiring is harmless: both paths set the same
-        // property to the same expression.
+        //
+        // On a core that ships the companion change this is redundant: the
+        // collector's applyCallbacks already routes `_selectionChange` to
+        // `onSelectionChange()` (`method_exists`-gated). It is NOT a fallback
+        // for cores that predate that change — those don't rewrite the
+        // `@selectionChange` directive either, so `_selectionChange` can never
+        // reach us. What it does buy is decoupling: the element works against
+        // a core that has the precompiler half without the collector half,
+        // which is exactly the configuration this repo's CI builds against.
+        // Double-wiring is harmless — both paths set the same property to the
+        // same expression.
         if (isset($attrs['_selectionChange'])) {
             $this->onSelectionChange($attrs['_selectionChange']);
         }
@@ -380,8 +386,12 @@ abstract class BaseTextInput extends Element
 
     /**
      * Coalescing window for `@selectionChange` events, in milliseconds.
-     * When unset the renderers default to 50ms — the prop is only
-     * serialized when explicitly configured. Blade:
+     * When unset the renderers default to 150ms — the prop is only
+     * serialized when explicitly configured.
+     *
+     * Values of 0 or less mean "use the renderer default"; positive values
+     * are floored at one frame (16ms) natively, since every emission costs a
+     * bridge frame plus a full component re-render. Blade:
      * `selection-debounce-ms` (or `selectionDebounceMs`).
      */
     public function selectionDebounceMs(int $ms): static
@@ -411,8 +421,13 @@ abstract class BaseTextInput extends Element
      * Caret / selection reporting. The handler is invoked as
      * `method(string $text, int $selectionStart, int $selectionEnd)` —
      * offsets in Unicode code points, `start === end` for a plain caret.
-     * Coalesced natively (50ms default; see `selectionDebounceMs()`).
-     * Never emitted for `secure` inputs (renderer-enforced).
+     * Coalesced natively (150ms default; see `selectionDebounceMs()`).
+     *
+     * Never emitted for `secure` inputs: the callback is not serialized at
+     * all when `secure()` is set, and both renderers additionally refuse to
+     * emit. Note that each event carries the FULL current text, independent
+     * of the `native:model` sync mode.
+     *
      * Blade: `@selectionChange="method"`.
      */
     public function onSelectionChange(string $method): static
@@ -432,7 +447,13 @@ abstract class BaseTextInput extends Element
         if ($this->submitCallback !== null) {
             $props['on_submit'] = $registry->register($this->submitCallback);
         }
-        if ($this->selectionChangeCallback !== null) {
+        // Selection reporting is suppressed for `secure` inputs at the SOURCE,
+        // not just in the renderers. Both renderers also refuse to emit, but
+        // that leaves a privacy-relevant invariant restated in every renderer —
+        // including any future one. Never serializing the callback id means a
+        // secure field cannot leak caret offsets no matter what the native side
+        // does with the prop.
+        if ($this->selectionChangeCallback !== null && empty($this->inputProps['secure'])) {
             // 'text_selection' kind tells NativeComponent::dispatch to decode
             // the event's TEXT_CHANGE payload ("{start},{end}\x1F{text}") and
             // call the handler with (text, selectionStart, selectionEnd).

--- a/tests/CollectorElementsTest.php
+++ b/tests/CollectorElementsTest.php
@@ -104,7 +104,15 @@ it('applies bare text input props and callbacks', function () {
     expect($registry->resolve($tree['props']['on_submit']))->toBe(['method' => 'onTextSubmit', 'args' => []]);
 });
 
-it('wires _selectionChange through the collector with the text_selection kind', function (string $type) {
+// NOTE ON WHAT THIS COVERS: the assertion is that an element handed a
+// `_selectionChange` attr ends up with a `text_selection`-kinded callback. It
+// does NOT prove the core's collector routes `_selectionChange` →
+// `onSelectionChange()`, because `BaseTextInput::applyAttributes` self-wires
+// the same attr. Against the core this repo's CI builds against (which has the
+// precompiler half but not the collector half) the self-wire is what makes
+// this pass. Both paths are intentional; the collector path is covered by the
+// companion core PR's own suite.
+it('gives a _selectionChange attr a text_selection-kinded callback', function (string $type) {
     NativeElementCollector::leaf($type, [
         'value' => 'hello',
         '_selectionChange' => 'onCaretMove',
@@ -131,7 +139,7 @@ it('serializes selection-debounce-ms only when set', function () {
 
     expect($tree['props']['selection_debounce_ms'])->toBe(120);
 
-    // Absent attr → absent prop: the 50ms default lives in the renderers,
+    // Absent attr → absent prop: the default window lives in the renderers,
     // never serialized from PHP.
     NativeElementCollector::reset();
     NativeElementCollector::leaf('outlined_text_input', [
@@ -151,6 +159,44 @@ it('accepts the camelCase selectionDebounceMs attribute', function () {
     $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
 
     expect($tree['props']['selection_debounce_ms'])->toBe(75);
+});
+
+it('never serializes a selection callback for a secure input', function (string $type) {
+    // Privacy invariant, enforced at the source rather than restated in every
+    // renderer: a secure field must not ship caret offsets, so the callback id
+    // is never registered and the native side has nothing to emit against.
+    NativeElementCollector::leaf($type, [
+        'secure' => true,
+        '_selectionChange' => 'onCaretMove',
+        'selection-debounce-ms' => 120,
+    ]);
+
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['props'])->not->toHaveKey('on_selection_change');
+    // The other callbacks on a secure field are untouched.
+    expect($tree['props']['secure'])->toBeTrue();
+})->with(['bare_text_input', 'outlined_text_input', 'filled_text_input']);
+
+it('suppresses the selection callback for a secure input via the fluent API', function () {
+    $registry = new CallbackRegistry;
+    $props = OutlinedTextInput::make()
+        ->onSelectionChange('trackCaret')
+        ->secure()
+        ->toArray($registry)['props'];
+
+    expect($props)->not->toHaveKey('on_selection_change');
+});
+
+it('still serializes the selection callback when secure is explicitly false', function () {
+    $registry = new CallbackRegistry;
+    $props = OutlinedTextInput::make()
+        ->onSelectionChange('trackCaret')
+        ->secure(false)
+        ->toArray($registry)['props'];
+
+    expect($props['on_selection_change'])->toBeInt();
+    expect($registry->kind($props['on_selection_change']))->toBe('text_selection');
 });
 
 it('registers selection change via the fluent API', function () {


### PR DESCRIPTION
Review follow-ups for #18, targeting `feat/text-input-selection` so they can be merged into it (or cherry-picked) rather than filed as comments. cc @simonhamp

The design in #18 is right — riding `TEXT_CHANGE` with a `text_selection` kind is zero-wire-change and the feature-off paths really are cheap early returns. Everything below is edge-case cleanup, and the four changes are independent.

## 1. iOS: report an end-caret event on programmatic value pushes

Today the same event produces three different behaviors:

| | behavior on a `value` push |
|---|---|
| Android (all 3 renderers) | `selectionReporter.flush(pushed)` — always fires, `(text, len, len)` |
| iOS, unfocused | **nothing** — `.onChange(of: text)` is gated on `isFocused` and `selection` is `nil` |
| iOS, focused | the **stale** cached `selStart`/`selEnd` clamped to the new length, not end-of-text |

That lands right on the mention-typeahead flow the PR pitches, where the handler rewrites the bound model. iOS now emits the end-caret event from `.onChange(of: serverValue)`, matching Android; the `.onChange(of: text)` pass that follows recomputes the identical payload and is dropped by the existing dedupe.

## 2. Both: unify `selection_debounce_ms`, default 50ms → 150ms

PHP only serializes the prop when configured, so natively "absent" and an explicit `0` are indistinguishable. Android's `if (it > 0) it else 50` mapped both to 50ms; iOS's `getInt(default: 50)` kept `0` and emitted immediately. Both now treat `<= 0` as "use the default".

Positive values are floored at one frame (16ms). Nothing clamped the low end before, so `selection-debounce-ms="1"` was legal and bought a bridge frame plus a full component re-render every millisecond of caret drag.

**The 150ms default is the one opinionated change in this PR** — isolated to a pair of named constants if you'd rather keep 50ms. The reasoning: every event carries the entire field text and costs a Livewire render plus a native tree diff, so 50ms is a lot to spend by default for a feature whose typical consumer (a mention typeahead) is human-paced.

## 3. PHP: never serialize `on_selection_change` for a `secure` input

Both renderers already refuse to emit, but that leaves a privacy-relevant invariant restated in every renderer — including any future one — with no test covering it. Suppressing in `resolveProps()` makes it unleakable regardless of what the native side does with the prop, and assertable from PHP. `->secure(false)` still registers; three tests cover it.

## 4. Docs and two comments that describe something other than what the code does

README gains a contract section: programmatic pushes, discontiguous selections reported as a span that **covers their gaps** (so `mb_substr($text, $start, $end - $start)` includes unselected text), and the read-only asymmetry — Android reports selection on read-only fields for copy support, iOS can't because `read-only` implies `.disabled`. Plus a callout that every event ships the full text independent of the `native:model` sync mode, so pairing `@selectionChange` with `.blur`/`.debounce` does **not** keep field contents off the wire the way the sync mode otherwise would.

Two comment corrections:

- **`BaseTextInput::applyAttributes`** describes the `_selectionChange` self-wire as a fallback for "cores that predate the `text_selection` callback kind". That case can't occur — such a core doesn't rewrite the `@selectionChange` directive either, so `_selectionChange` never reaches the element. What the self-wire actually buys is decoupling from the collector half, which is what this repo's CI builds against (`tests.yml` targets `dev-element`, and `origin/element`'s `NativeElementCollector` has no `_selectionChange` handling). Worth stating plainly, because it means `it('wires _selectionChange through the collector…')` isn't testing the collector — it would stay green even if the collector change in NativePHP/mobile-air#221 never merged. Renamed accordingly.
- **`scalarOffset`** claims its clamp "keeps a momentarily-stale index from trapping `distance`". The clamp bounds range, not scalar *alignment*. Swift rounds rather than traps for a misaligned index in the scalar view, so the worst case is an off-by-one, not a crash — the code is fine, the comment just promises more than it delivers.

## Not addressed here

- **The `^4.0` constraint.** The README's arity warning is really a dependency-resolution problem: once NativePHP/mobile-air#221 lands, `composer.json` should pin a version that can't resolve to a core lacking the kind. Moot if both merge before `4.0.0` stable — worth confirming that's the plan rather than leaving it to a README note.
- **`cappedTo` and surrogate pairs.** `text.take(maxLength)` is UTF-16 units, so an over-long paste can sever a pair and leave a lone surrogate that `codePointCount` then counts as one. Pre-existing semantics, but the offsets now flow to PHP where `mb_substr` on the mangled UTF-8 may misalign. Low priority; didn't want to change `max_length` behavior in a review PR.
- **Neither renderer change is typechecked.** `tests.yml` does run a `swiftc -parse` pass over `resources/ios/*.swift` — but parse-only doesn't resolve types, so API misuse and availability errors sail through it, and (per the job's own comment) Kotlin has no parse-only mode and isn't checked at all. I verified the new SwiftUI surface by hand against the iOS 26.5 SDK `.swiftinterface`: `TextSelection` is `@available(iOS 18.0, …)` and conforms to `Equatable`/`Hashable` (so `.onChange(of: selection)` is valid), the `.selection`/`.multiSelection` cases match, and `TextField<S: StringProtocol>(_:text:selection:prompt:axis:)` exists with `axis: Axis? = nil` — so both the single-line and `axis: .vertical` call sites resolve against the 18.2 deployment target. That's the API surface holding up, not a build; a real device build is still the gate.

## Verification

Pint clean. Pest not run locally — that needs `composer install` inside a plugin repo, which the plugins-tree rules forbid — so CI is the check on the three new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
