### PR TITLE
Scroll-view: honour auto_scroll_to, gap on Android, and chrome collapse

### DIFF
--- a/resources/android/ContainerRenderers.kt
+++ b/resources/android/ContainerRenderers.kt
@@ -345,8 +345,36 @@ object ScrollViewRenderer {
             detectVerticalDragGestures(onDragStart = { keyboardController?.hide() }) { _, _ -> }
         }
 
+        // Item spacing from the `gap-*` class. The flex engine lays out
+        // ordinary containers, but a lazy list arranges its own items, so the
+        // gap has to be applied here as Compose arrangement or it is silently
+        // dropped. iOS reads the same layout gap into LazyVStack/LazyHStack
+        // spacing — without this, `gap-2` on a scroll-view spaces on iOS and
+        // does nothing on Android.
+        val gap = (node.layout?.gap ?: 0f).dp
+
+        // Explicit index targeting (`auto-scroll-to`) wins over bottom
+        // anchoring when both are set — the author named a specific child,
+        // so honour that rather than yanking them to the end. -1 is the
+        // "unset" sentinel; out-of-range indices are ignored rather than
+        // throwing, so content that hasn't arrived yet is a no-op.
+        val autoScrollIndex = node.props.getInt("auto_scroll_to", -1)
+        val hasAutoScroll = autoScrollIndex >= 0
+
         if (horizontal) {
-            LazyRow(modifier = modifier) {
+            val rowState = rememberLazyListState()
+
+            LaunchedEffect(autoScrollIndex) {
+                if (autoScrollIndex in node.children.indices) {
+                    rowState.animateScrollToItem(autoScrollIndex)
+                }
+            }
+
+            LazyRow(
+                modifier = modifier,
+                state = rowState,
+                horizontalArrangement = Arrangement.spacedBy(gap),
+            ) {
                 items(node.children, key = { it.id }) { child ->
                     NodeView(node = child)
                 }
@@ -360,19 +388,37 @@ object ScrollViewRenderer {
             // item with a max offset lands at the very bottom regardless of how
             // the content is nested. Hooks are called unconditionally to satisfy
             // Compose's rules; the work is gated on the prop.
-            val stickBottom = node.props.getString("scroll_anchor", "") == "bottom"
+            val stickBottom = !hasAutoScroll && node.props.getString("scroll_anchor", "") == "bottom"
             val listState = rememberLazyListState()
             val didInitialScroll = remember { mutableStateOf(false) }
             val contentSignal = if (stickBottom) totalDescendants(node) else 0
 
-            LaunchedEffect(stickBottom, contentSignal) {
-                if (stickBottom && node.children.isNotEmpty()) {
+            // A programmatic scroll emits no nested-scroll deltas, so a
+            // collapsing top bar never learns the content moved and a large
+            // title stays stranded fully expanded. Drive it explicitly.
+            val chromeScroll = LocalChromeScrollController.current
+
+            LaunchedEffect(stickBottom, contentSignal, autoScrollIndex) {
+                // Jump without animation the first time (opening at the target
+                // shouldn't look like a scroll), animate every move after.
+                if (hasAutoScroll) {
+                    if (autoScrollIndex in node.children.indices) {
+                        if (!didInitialScroll.value) {
+                            didInitialScroll.value = true
+                            listState.scrollToItem(autoScrollIndex)
+                        } else {
+                            listState.animateScrollToItem(autoScrollIndex)
+                            chromeScroll?.collapse()
+                        }
+                    }
+                } else if (stickBottom && node.children.isNotEmpty()) {
                     val lastIndex = node.children.size - 1
                     if (!didInitialScroll.value) {
                         didInitialScroll.value = true
                         listState.scrollToItem(lastIndex, Int.MAX_VALUE) // jump on open
                     } else {
                         listState.animateScrollToItem(lastIndex, Int.MAX_VALUE)
+                        chromeScroll?.collapse()
                     }
                 }
             }
@@ -404,7 +450,10 @@ object ScrollViewRenderer {
                     // Dp.Infinity)` would be catastrophic, so fall through to
                     // the normal path — there is no viewport to fill against.
                     val viewport = maxHeight.takeIf { it.value.isFinite() && it.value > 0f }
-                    LazyColumn(state = listState) {
+                    LazyColumn(
+                        state = listState,
+                        verticalArrangement = Arrangement.spacedBy(gap),
+                    ) {
                         items(node.children, key = { it.id }) { child ->
                             val layout = child.layout
                             if (viewport != null && layout?.heightMode == SizeMode.FILL) {
@@ -445,7 +494,11 @@ object ScrollViewRenderer {
                     }
                 }
             } else {
-                LazyColumn(modifier = scrollModifier, state = listState) {
+                LazyColumn(
+                    modifier = scrollModifier,
+                    state = listState,
+                    verticalArrangement = Arrangement.spacedBy(gap),
+                ) {
                     items(node.children, key = { it.id }) { child ->
                         NodeView(node = child)
                     }

--- a/resources/ios/NativeUIScrollViewRenderer.swift
+++ b/resources/ios/NativeUIScrollViewRenderer.swift
@@ -16,7 +16,10 @@ struct NativeUIScrollViewRenderer: View {
         let showsIndicators = node.props.getBool("shows_indicators", default: true)
         let spacing = CGFloat(node.layout?.gap ?? 0)
         let axis = node.props.getString("axis", default: "")
-        let stickBottom = node.props.getString("scroll_anchor", default: "") == "bottom"
+        // Explicit index targeting (`auto-scroll-to`) wins over bottom
+        // anchoring when both are set — the author named a specific child,
+        // so honour that rather than yanking them to the end.
+        let stickBottom = !hasAutoScroll && node.props.getString("scroll_anchor", default: "") == "bottom"
         let messageSignal = stickBottom ? Self.descendantCount(node) : 0
 
         // 2D mode. Bypass the Lazy stacks (which force 1D layout) and use a
@@ -53,15 +56,30 @@ struct NativeUIScrollViewRenderer: View {
             }
             .scrollDismissesKeyboard(.interactively)
         } else if horizontal {
-            ScrollView(.horizontal, showsIndicators: showsIndicators) {
-                LazyHStack(alignment: .top, spacing: spacing) {
-                    ForEach(node.children) { child in
-                        NodeView(node: child)
-                            .equatable()
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: showsIndicators) {
+                    LazyHStack(alignment: .top, spacing: spacing) {
+                        ForEach(node.children) { child in
+                            NodeView(node: child)
+                                .equatable()
+                        }
+                    }
+                }
+                .scrollDismissesKeyboard(.interactively)
+                .onAppear {
+                    guard hasAutoScroll else { return }
+                    // Defer past first layout — lazy content isn't measured
+                    // yet inside onAppear, so an immediate scrollTo no-ops.
+                    DispatchQueue.main.async {
+                        Self.scroll(proxy, to: autoScrollIndex, in: node, anchor: .leading)
+                    }
+                }
+                .onChange(of: autoScrollIndex) { index in
+                    withAnimation(.easeOut(duration: 0.25)) {
+                        Self.scroll(proxy, to: index, in: node, anchor: .leading)
                     }
                 }
             }
-            .scrollDismissesKeyboard(.interactively)
         } else if hasFillHeightChild {
             // A `fill` / `h-full` child asked to be at least as tall as the
             // VIEWPORT — the "short screen centred, still scrolls when the
@@ -93,6 +111,17 @@ struct NativeUIScrollViewRenderer: View {
             )
         }
     }
+
+    /// The `auto-scroll-to` target index, or `-1` when unset.
+    ///
+    /// A computed property rather than a `body` local because `verticalScroll`
+    /// is a separate helper and needs the same value; `hasFillHeightChild`
+    /// above sets the precedent.
+    private var autoScrollIndex: Int {
+        node.props.getInt("auto_scroll_to", default: -1)
+    }
+
+    private var hasAutoScroll: Bool { autoScrollIndex >= 0 }
 
     /// Whether any DIRECT child asked to fill the scroll view's height.
     ///
@@ -171,11 +200,22 @@ struct NativeUIScrollViewRenderer: View {
             }
             .scrollDismissesKeyboard(.interactively)
             .onAppear {
-                guard stickBottom else { return }
+                guard stickBottom || hasAutoScroll else { return }
                 // Defer past first layout — lazy content isn't measured yet
                 // inside onAppear, so an immediate scrollTo no-ops.
                 DispatchQueue.main.async {
-                    proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+                    if hasAutoScroll {
+                        Self.scroll(proxy, to: autoScrollIndex, in: node, anchor: .top)
+                    } else {
+                        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
+                    }
+                }
+            }
+            // Follow an `auto-scroll-to` index as it moves — a chat log
+            // binding it to the last message re-pins on every new arrival.
+            .onChange(of: autoScrollIndex) { index in
+                withAnimation(.easeOut(duration: 0.25)) {
+                    Self.scroll(proxy, to: index, in: node, anchor: .top)
                 }
             }
             .onChange(of: messageSignal) { _ in
@@ -233,6 +273,17 @@ struct NativeUIScrollViewRenderer: View {
     }
 
     private static let bottomAnchorID = "nphp.scroll.bottom.anchor"
+
+    /// Bring the direct child at `index` into view. Indexes the scroll-view's
+    /// OWN children, so a log wrapped in a `<column>` addresses the column,
+    /// not the messages inside it. A negative or out-of-range index is a
+    /// no-op — content that hasn't arrived yet must not crash the render, and
+    /// `-1` is the "unset" sentinel for the prop.
+    private static func scroll(_ proxy: ScrollViewProxy, to index: Int, in node: NativeUINode, anchor: UnitPoint) {
+        guard index >= 0, index < node.children.count else { return }
+
+        proxy.scrollTo(node.children[index].id, anchor: anchor)
+    }
 
     /// Recursive descendant count — a content signal that changes whenever a
     /// message is added anywhere in the subtree (even inside a wrapping


### PR DESCRIPTION
Three scroll-view renderer gaps, all surfaced while building a chat screen.

> [!IMPORTANT]
> **Depends on NativePHP/mobile-air#241** — this consumes `ChromeScrollController` from core and will **not compile** without it. Merge and release that first.

## 1. `auto_scroll_to` was never implemented

`ScrollView::autoScrollTo()` sets the prop, but no renderer on either platform read it — it was written into the wire payload and dropped on the floor. `BenchmarkComponent.php:992` relies on it to scroll a long list, so that benchmark scenario has been measuring a static list.

- **iOS** — reuses the `ScrollViewReader` already on the vertical branch, scrolling to the target child's id; the horizontal branch gains a reader so it behaves the same.
- **Android** — drives `LazyColumn`'s existing `listState` by index; `LazyRow` gains a state to drive.

Both jump without animation on first appear (opening at a target shouldn't look like a scroll) and animate later moves, matching the existing `scroll-anchor` path. An explicit index wins over `scroll-anchor="bottom"`. Negative and out-of-range indices are no-ops.

## 2. `gap-*` was ignored on Android

The flex engine lays out ordinary containers, but a lazy list arranges its own items — so `gap` was read on iOS (into `LazyVStack`/`LazyHStack` spacing) and silently dropped on Android.

That gap matters more than it looks. Without it the only way to space a list is wrapping it in a `<column>`, which collapses the entire list into a **single lazy item** — killing virtualization. Measured on a real chat log: `directChildren=1`, `canScrollForward=false`, and `firstVisibleItemScrollOffset` climbing past 1000px *inside* one item.

## 3. Programmatic scrolls left a collapsing top bar expanded

Both scroll paths now drive core's `ChromeScrollController` after moving the list. Skipped on the initial jump — opening a screen shouldn't animate the chrome shut.

## Compatibility — please read

Two user-visible behaviour changes for existing apps:

- **`gap` on a scroll-view now spaces on Android.** Any app relying on the current no-op will see layouts shift. Arguably the fix, but it *is* a change.
- **`autoScrollTo()` now scrolls.** Anyone who called it and got nothing will now get scrolling.

Also `auto_scroll_to` taking precedence over `scroll_anchor` — previously moot, since `auto_scroll_to` did nothing.

## Testing status — partial, please review accordingly

- **Chrome collapse: verified on a physical Pixel 9.** Bar travels 0 → -231, then short-circuits on repeat messages.
- **`auto_scroll_to` (both platforms) and the Android gap fix: NOT yet exercised on device.** The test app uses `scroll-anchor="bottom"` with a wrapped log, so neither path was hit. Reviewed against surrounding code, imports verified, but they want a real build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)