### PR TITLE
fix(bare-text-input): align cursor with placeholder on Android

### DIFF
--- a/resources/android/BareTextInputRenderer.kt
+++ b/resources/android/BareTextInputRenderer.kt
@@ -1,6 +1,7 @@
 package com.nativephp.plugins.native_ui.ui
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -12,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -108,14 +110,21 @@ object BareTextInputRenderer {
             ),
             singleLine = !props.multiline,
             decorationBox = { innerTextField ->
-                if (text.isEmpty() && props.placeholder.isNotEmpty()) {
-                    Text(
-                        text = props.placeholder,
-                        color = placeholderColor,
-                        fontSize = props.textSize.sp
-                    )
+                // Stack the placeholder and the real field in a centered Box.
+                // Without this, Compose lays both out top-start independently —
+                // if their intrinsic line heights differ even slightly, the
+                // visible cursor and the placeholder glyph drift apart
+                // vertically, showing the cursor visibly above the placeholder.
+                Box(contentAlignment = Alignment.CenterStart) {
+                    if (text.isEmpty() && props.placeholder.isNotEmpty()) {
+                        Text(
+                            text = props.placeholder,
+                            color = placeholderColor,
+                            fontSize = props.textSize.sp
+                        )
+                    }
+                    innerTextField()
                 }
-                innerTextField()
             },
             keyboardActions = KeyboardActions(onAny = { props.dispatchSubmit?.invoke(text) })
         )


### PR DESCRIPTION
## Summary

On Android, `<bare-text-input>`'s cursor can render visibly above the placeholder
text instead of level with it.

`BasicTextField`'s `decorationBox` puts the placeholder `Text` and the real
`innerTextField` (which owns the cursor) directly in the lambda body with no
wrapping container. Compose lays out multiple composables inside a
`decorationBox` top-start by default (it isn't an implicit `Box`), so when the
two elements' intrinsic line-height metrics diverge even slightly, the visible
cursor and the placeholder glyph end up at different vertical positions.

The outlined/filled variants don't have this problem — they use Material3's
own `TextField`/`OutlinedTextField`, whose built-in decoration already centers
the label/placeholder/content. Only the bare variant hand-rolls a
`decorationBox`.

## Fix

Wrap the two children in `Box(contentAlignment = Alignment.CenterStart)`, so
they share one baseline. Two-line change plus the two new imports it needs
(`androidx.compose.foundation.layout.Box`, `androidx.compose.ui.Alignment`).

## Context

Ran into this building a POS app on `nativephp/mobile-ui` — a `<bare-text-input>`
wrapped in a styled row (to mimic a filled input with a separate label above
it, since `outlined`/`filled` bake the label inside the box) showed the cursor
sitting above the placeholder as soon as the field was focused.

## Verification

I don't have Android build tooling in the environment I'm working from, so I
haven't compiled/run this exact patched file through a full Gradle build
myself. I did apply the identical change locally in a consuming app's synced
`nativephp/android` project (copied from this same vendor source) and it's
pending a device rebuild + confirmation there. Flagging this rather than
overclaiming — happy to follow up with a device screenshot once that build
runs, or for a maintainer to sanity-check independently; the change itself is
a well-known Compose pattern (an un-boxed `decorationBox` with multiple
children needs an explicit alignment container) so I'm fairly confident in
it, just noting the gap in my own verification.

I didn't add an automated test — this repo's Kotlin isn't compiled or
rendered in CI/the Pest suite (per `tests.yml`'s own comment, Android syntax
is "covered by the consuming app build instead"), and the PHP-side wire-tree
test harness doesn't exercise actual Compose layout, so there isn't an
existing mechanism that would catch a regression here. Let me know if you'd
want a different kind of coverage added.