### PR TITLE
fix: per-platform icon attributes on Button/Chip/Tab, and iOS button height parity

### DIFF
--- a/resources/ios/NativeUIButtonRenderer.swift
+++ b/resources/ios/NativeUIButtonRenderer.swift
@@ -393,6 +393,14 @@ private struct ButtonContent: View {
                 if !icon.isEmpty {
                     Image(systemName: getIconForName(icon))
                         .nuiScaledFont(size: iconSize)
+                        // Pin the layout height to iconSize. SF Symbols report
+                        // per-symbol intrinsic heights at the same point size,
+                        // so without this a control's height depends on which
+                        // symbol it carries — two `size="sm"` buttons side by
+                        // side render ~2pt apart. Height only, never width:
+                        // unlike Material's square grid, SF Symbols have varying
+                        // aspect ratios and a square frame would distort them.
+                        .frame(height: iconSize)
                 }
                 if !label.isEmpty {
                     Text(label).nuiScaledFont(size: textSize, weight: .medium, fontName: fontName).lineSpacing(lineSpacing)
@@ -400,6 +408,7 @@ private struct ButtonContent: View {
                 if !iconTrailing.isEmpty {
                     Image(systemName: getIconForName(iconTrailing))
                         .nuiScaledFont(size: iconSize)
+                        .frame(height: iconSize)
                 }
             }
         }

--- a/src/Elements/Button.php
+++ b/src/Elements/Button.php
@@ -68,11 +68,25 @@ class Button extends Element
         if (! empty($attrs['loading'])) {
             $this->loading();
         }
-        if (isset($attrs['icon'])) {
-            $this->icon($attrs['icon']);
+        // Platform icon overrides, matching the core elements' convention
+        // (`:ios-icon` / `:android-icon`, with `<icon>`-style `:ios` /
+        // `:android` accepted as aliases). Button is multi-slot so it can't
+        // use HasPlatformIcon; without this the shared name was the only
+        // value reaching icon(), leaving an SF Symbol to render nothing on
+        // Android and a Material ligature nothing on iOS.
+        $iosIcon = $attrs['ios-icon'] ?? $attrs['iosIcon'] ?? $attrs['ios'] ?? null;
+        $androidIcon = $attrs['android-icon'] ?? $attrs['androidIcon'] ?? $attrs['android'] ?? null;
+
+        if (isset($attrs['icon']) || $iosIcon !== null || $androidIcon !== null) {
+            $this->icon($attrs['icon'] ?? null, $iosIcon, $androidIcon);
         }
-        if (isset($attrs['icon-trailing']) || isset($attrs['iconTrailing'])) {
-            $this->iconTrailing($attrs['icon-trailing'] ?? $attrs['iconTrailing']);
+
+        $iosTrailing = $attrs['ios-icon-trailing'] ?? $attrs['iosIconTrailing'] ?? null;
+        $androidTrailing = $attrs['android-icon-trailing'] ?? $attrs['androidIconTrailing'] ?? null;
+        $sharedTrailing = $attrs['icon-trailing'] ?? $attrs['iconTrailing'] ?? null;
+
+        if ($sharedTrailing !== null || $iosTrailing !== null || $androidTrailing !== null) {
+            $this->iconTrailing($sharedTrailing, $iosTrailing, $androidTrailing);
         }
         // Custom font by name — the token is a font file (minus extension)
         // bundled from the app's resources/fonts/ by the copy_assets hook.

--- a/src/Elements/Chip.php
+++ b/src/Elements/Chip.php
@@ -52,8 +52,13 @@ class Chip extends Element
         if (isset($attrs['value'])) {
             $this->selected((bool) $attrs['value']);
         }
-        if (isset($attrs['icon'])) {
-            $this->icon($attrs['icon']);
+        // `:ios-icon` / `:android-icon` (with `<icon>`-style `:ios` /
+        // `:android` as aliases), matching the core elements.
+        $iosIcon = $attrs['ios-icon'] ?? $attrs['iosIcon'] ?? $attrs['ios'] ?? null;
+        $androidIcon = $attrs['android-icon'] ?? $attrs['androidIcon'] ?? $attrs['android'] ?? null;
+
+        if (isset($attrs['icon']) || $iosIcon !== null || $androidIcon !== null) {
+            $this->icon($attrs['icon'] ?? null, $iosIcon, $androidIcon);
         }
         if (! empty($attrs['disabled'])) {
             $this->disabled();

--- a/src/Elements/Tab.php
+++ b/src/Elements/Tab.php
@@ -34,8 +34,13 @@ class Tab extends Element
         if (isset($attrs['label'])) {
             $this->tabProps['label'] = $attrs['label'];
         }
-        if (isset($attrs['icon'])) {
-            $this->icon($attrs['icon']);
+        // `:ios-icon` / `:android-icon` (with `<icon>`-style `:ios` /
+        // `:android` as aliases), matching the core elements.
+        $iosIcon = $attrs['ios-icon'] ?? $attrs['iosIcon'] ?? $attrs['ios'] ?? null;
+        $androidIcon = $attrs['android-icon'] ?? $attrs['androidIcon'] ?? $attrs['android'] ?? null;
+
+        if (isset($attrs['icon']) || $iosIcon !== null || $androidIcon !== null) {
+            $this->icon($attrs['icon'] ?? null, $iosIcon, $androidIcon);
         }
 
         $this->applyA11yAttributes($attrs);

--- a/tests/MultiSlotIconAttrTest.php
+++ b/tests/MultiSlotIconAttrTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\ElementRegistry;
+use Native\Mobile\Edge\NativeElementCollector;
+use Native\Mobile\Icon\AndroidSymbol;
+use Native\Mobile\Icon\IosSymbol;
+use Native\Mobile\Platform;
+use Native\Mobile\UI\Elements\Button;
+use Native\Mobile\UI\Elements\Chip;
+use Native\Mobile\UI\Elements\Tab;
+
+/**
+ * `:ios-icon` / `:android-icon` blade attributes on the elements that were
+ * previously shared-name-only — Button (multi-slot, so it can't use
+ * HasPlatformIcon), plus Chip and Tab. Fixture enums are inline and
+ * distinctly named because Pest loads every test file into one process.
+ */
+enum MultiSlotIos: string implements IosSymbol
+{
+    case Wave = 'wave.3.right';
+}
+
+enum MultiSlotAndroid: string implements AndroidSymbol
+{
+    public function variant(): string
+    {
+        return 'filled';
+    }
+
+    case Nfc = 'nfc';
+}
+
+beforeEach(function () {
+    NativeElementCollector::reset();
+    ElementRegistry::reset();
+    ElementRegistry::register('button', Button::class);
+    ElementRegistry::register('chip', Chip::class);
+    ElementRegistry::register('tab', Tab::class);
+});
+
+afterEach(function () {
+    NativeElementCollector::reset();
+    ElementRegistry::reset();
+    Platform::set(null);
+});
+
+function iconPropsFor(string $type, array $attrs): array
+{
+    NativeElementCollector::leaf($type, $attrs);
+
+    return NativeElementCollector::collect()->toArray(new CallbackRegistry)['props'];
+}
+
+it('resolves a button android-icon override on android', function () {
+    Platform::set('android');
+
+    $props = iconPropsFor('button', [
+        'label' => 'Add',
+        'icon' => 'wave.3.right',
+        'android-icon' => 'nfc',
+    ]);
+
+    expect($props['leading_icon'])->toBe('nfc');
+});
+
+it('keeps the shared button icon on ios when only android is overridden', function () {
+    Platform::set('ios');
+
+    $props = iconPropsFor('button', [
+        'label' => 'Add',
+        'icon' => 'wave.3.right',
+        'android-icon' => 'nfc',
+    ]);
+
+    expect($props['leading_icon'])->toBe('wave.3.right');
+});
+
+it('accepts icon-less buttons that declare only per-platform overrides', function () {
+    Platform::set('android');
+
+    $props = iconPropsFor('button', [
+        'label' => 'Add',
+        'ios-icon' => 'wave.3.right',
+        'android-icon' => 'nfc',
+    ]);
+
+    expect($props['leading_icon'])->toBe('nfc');
+});
+
+it('resolves per-platform overrides on the trailing button slot', function () {
+    Platform::set('android');
+
+    $props = iconPropsFor('button', [
+        'label' => 'Next',
+        'icon-trailing' => 'chevron.right',
+        'android-icon-trailing' => 'chevron_right',
+    ]);
+
+    expect($props['trailing_icon'])->toBe('chevron_right');
+});
+
+it('carries the material variant through from an android enum case', function () {
+    Platform::set('android');
+
+    $props = iconPropsFor('button', [
+        'label' => 'Add',
+        'ios' => MultiSlotIos::Wave,
+        'android' => MultiSlotAndroid::Nfc,
+    ]);
+
+    expect($props['leading_icon'])->toBe('nfc')
+        ->and($props['leading_icon_variant'])->toBe('filled');
+});
+
+it('leaves a button with no icon of any kind alone', function () {
+    Platform::set('ios');
+
+    expect(iconPropsFor('button', ['label' => 'Plain']))
+        ->not->toHaveKey('leading_icon');
+});
+
+it('resolves per-platform icon attributes on a chip', function () {
+    Platform::set('android');
+
+    expect(iconPropsFor('chip', [
+        'label' => 'Nearby',
+        'icon' => 'wave.3.right',
+        'android-icon' => 'nfc',
+    ])['icon'])->toBe('nfc');
+});
+
+it('resolves per-platform icon attributes on a tab', function () {
+    Platform::set('android');
+
+    expect(iconPropsFor('tab', [
+        'label' => 'Devices',
+        'icon' => 'wave.3.right',
+        'android-icon' => 'nfc',
+    ])['icon'])->toBe('nfc');
+});
+
+it('still honours the shared icon name when no override is given', function () {
+    Platform::set('android');
+
+    expect(iconPropsFor('chip', ['label' => 'Nearby', 'icon' => 'nfc'])['icon'])
+        ->toBe('nfc');
+});


### PR DESCRIPTION
Two related cross-platform gaps, both surfaced by the same two-button row.

---

## 1. `:ios-icon` / `:android-icon` don't work on Button, Chip or Tab

These attributes are implemented on the core elements — `TopBarAction`, `Fab`, `BottomNavItem`, `Icon` — but `Button`, `Chip` and `Tab` only ever passed the shared name through:

```php
if (isset($attrs['icon'])) {
    $this->icon($attrs['icon']);
}
```

All three **already accept** per-platform overrides — `Chip` and `Tab` via `HasPlatformIcon`, `Button` via its own multi-slot `icon()` / `iconTrailing()`. The overrides were simply unreachable from Blade.

The practical effect: an SF Symbol name renders **nothing at all** on Android, and a Material ligature nothing on iOS. Hit it with:

```blade
<native:button label="Ajouter via NFC" icon="wave.3.right" android-icon="nfc" />
```

`wave.3.right` has no Material equivalent, so the Android button had no icon and there was no way to say so — short of an `isAndroid()` ternary in the view.

They now read `ios-icon` / `android-icon`, with the `<icon>`-style `ios` / `android` accepted as aliases. `Button` also covers its trailing slot via `ios-icon-trailing` / `android-icon-trailing`.

## 2. iOS button height depends on which icon it carries

The iOS renderer draws the icon as a font glyph:

```swift
Image(systemName: getIconForName(icon)).nuiScaledFont(size: iconSize)
```

SF Symbols report **per-symbol intrinsic heights** at the same point size, and the control height is content-driven — so two `size="sm"` buttons side by side render at different heights purely because of their symbols.

Measured on the simulator, same row, same `size`:

| | `wave.3.right` | `qrcode` | delta |
|---|---|---|---|
| **iOS, before** | 29.33pt | 27.00pt | **2.33pt** |
| **iOS, after** | 27.00pt | 27.00pt | **0** |
| **Android** | 85px | 85px | 0 (never affected) |

Isolated by swapping both buttons to the *same* icon and re-measuring: identical icons → 0px delta, different icons → 7px @3x. Nothing else changed.

Android is unaffected because `MaterialIcon(name, size = iconSize)` takes a fixed square.

Pinning the icon's layout height to `iconSize` makes the height depend on `size` alone. **Height only, never width** — unlike Material's square grid, SF Symbols have varying aspect ratios and a square frame would distort wide glyphs. Verified on-device that `wave.3.right` still renders un-clipped and undistorted.

---

## Tests

`tests/MultiSlotIconAttrTest.php` — 9 cases covering the android/ios override paths, the shared-name fallback, override-only (no shared name), the trailing slot, material-variant propagation from an enum case, and the no-icon case. Full suite **159 passed**; Pint clean.

The Swift change is visual and covered by the measurements above rather than a unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)