### PR TITLE
chore: install Pint as a dev dependency

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -16,14 +16,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Pint is a standalone formatter — it needs no project vendor/, so this
-      # job skips composer entirely.
-      - name: Setup PHP with Pint
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
           coverage: none
-          tools: pint
+
+      # Pint needs no project vendor/ (a full install would drag in the
+      # private nativephp/mobile auth), but install it under the SAME
+      # constraint as composer.json's require-dev so CI and a local
+      # `composer lint` agree on the version instead of drifting apart.
+      - name: Install Pint
+        run: composer global require "laravel/pint:^1.24" --no-interaction
 
       - name: Check code style
         run: pint --test

--- a/composer.json
+++ b/composer.json
@@ -29,11 +29,14 @@
         }
     },
     "require-dev": {
+        "laravel/pint": "^1.24",
         "orchestra/testbench": "^10.0",
         "pestphp/pest": "^3.0"
     },
     "scripts": {
-        "test": "pest"
+        "test": "pest",
+        "lint": "pint",
+        "lint:test": "pint --test"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
## Why

Running \`vendor/bin/pint\` locally after \`composer install\` fails — Pint was never a dependency of this repo. CI sidesteps it by installing Pint as a standalone setup-php tool, which also means CI's Pint version can drift from anything contributors use.

## What

- \`laravel/pint: ^1.24\` added to \`require-dev\`, with \`composer lint\` (fix) and \`composer lint:test\` (check) scripts.
- The CI job still installs Pint standalone (a full \`composer install\` would need the private \`nativephp/mobile\` auth for a style check), but now pins the same \`^1.24\` constraint as composer.json instead of taking whatever setup-php ships.
- Verified the whole repo passes \`pint --test\` (Pint 1.30.3) — no style diffs in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)