### PR TITLE
Fix custom fonts scaling twice with Dynamic Type on iOS

### DIFF
--- a/resources/ios/NativeUIFontResolver.swift
+++ b/resources/ios/NativeUIFontResolver.swift
@@ -36,7 +36,14 @@ enum NativeUIFontResolver {
     private static let extensions = ["ttf", "otf", "ttc"]
 
     /// A SwiftUI `Font` for a bundled token at `size`, or nil to fall back.
-    /// `size` is used as-is (callers pass an already-Dynamic-Type-scaled value).
+    /// `size` is used as-is (callers pass an already-Dynamic-Type-scaled value),
+    /// so the font is built with `Font.custom(_:fixedSize:)`. The `size:` variant
+    /// would scale relative to `.body` a SECOND time on top of the caller's
+    /// `@ScaledMetric`, squaring the multiplier — invisible at the default text
+    /// size (where it is 1.0) and roughly 1.8x at xxxLarge. The `UIFont` branch
+    /// below is already non-scaling, and the system-font fallback in
+    /// `NUIScaledFontModifier` uses fixed-size `.system(size:)` for the same
+    /// reason.
     ///
     /// With `italic`, a font whose family has a real italic face is returned
     /// upright — the caller's `Text.italic()` / `Font.italic()` selects the
@@ -60,7 +67,7 @@ enum NativeUIFontResolver {
             return Font(UIFont(descriptor: descriptor, size: size))
         }
 
-        return Font.custom(name, size: size)
+        return Font.custom(name, fixedSize: size)
     }
 
     /// Whether an italic request for this token needs a synthesized oblique


### PR DESCRIPTION
Fixes #33.

### The problem

`NUIScaledFontModifier` scales the design point size through Dynamic Type:

```swift
// resources/ios/NativeUITheme.swift:223
_size = ScaledMetric(wrappedValue: size, relativeTo: .body)
```

and then passes the result to the resolver, which built the font with the *scaling* initialiser:

```swift
// resources/ios/NativeUIFontResolver.swift:63
return Font.custom(name, size: size)
```

`Font.custom(_:size:)` also scales relative to `.body`, so the multiplier was applied twice. The resolver's docblock already stated that callers pass an already-scaled value, so single scaling looks like the original intent.

### The change

One line, plus a comment explaining why so it does not get "fixed" back later:

```diff
-        return Font.custom(name, size: size)
+        return Font.custom(name, fixedSize: size)
```

This makes all three paths in the same code agree. The `UIFont(descriptor:size:)` branch immediately above was already non-scaling, and the system-font fallback in `NUIScaledFontModifier` uses fixed-size `.system(size:)`. Only the custom-font path was scaling twice, which is why apps that set a `fonts.default` alias saw it on every element rather than just on headings.

### Effect

Body-style multiplier before and after:

| Text Size | Before | After |
| --- | --- | --- |
| Large (default) | 1.00x | 1.00x |
| xxLarge | 1.53x | 1.24x |
| xxxLarge | 1.82x | 1.35x |
| Accessibility 1 | 2.71x | 1.65x |

Text still tracks the user's preferred content size, it just does so once. Nothing changes at the default Text Size, where the multiplier is 1.0 and squaring it is a no-op. That is also why the bug is easy to miss in development: it only appears on a device whose owner has raised Text Size.

Android's equivalent path uses `.sp` and already scales once, so this brings the two platforms back into agreement.