### PR TITLE
Fix dead list-item taps and unthemed List background on iOS

### DIFF
--- a/resources/ios/NativeUIListItemRenderer.swift
+++ b/resources/ios/NativeUIListItemRenderer.swift
@@ -115,6 +115,11 @@ struct NativeUIListItemRenderer: View {
         .padding(.vertical, 12)
         .background(containerColor != 0 ? Color(argb: containerColor) : Color.clear)
         .opacity(disabled ? 0.5 : 1.0)
+        // Without an explicit content shape, onTapGesture only registers on
+        // opaque pixels — the padding and the Spacer gap between text and
+        // trailing content (most of the row) are tap-dead. Make the whole
+        // row bounds hittable before attaching @tap / @longPress handlers.
+        .contentShape(Rectangle())
         .applyClickHandlers(node: node)
     }
 

--- a/resources/ios/NativeUIListRenderer.swift
+++ b/resources/ios/NativeUIListRenderer.swift
@@ -85,6 +85,7 @@ struct NativeUIListRenderer: View {
                 }
             }
             .modifier(GroupedOrPlainListStyle(grouped: grouped))
+            .modifier(ListBackgroundModifier(node: node))
             .scrollDismissesKeyboard(.interactively)
             .refreshable {
                 if onRefreshCb != 0 {
@@ -204,6 +205,28 @@ private struct GroupedOrPlainListStyle: ViewModifier {
             content.listStyle(.insetGrouped)
         } else {
             content.listStyle(.plain)
+        }
+    }
+}
+
+/// SwiftUI's List paints the system (grouped) background and ignores the
+/// node's own background style, so a themed screen (`bg-theme-background`)
+/// renders on the stock gray instead of the app's palette. When the node
+/// declares a background, hide the system scroll background and paint the
+/// node's color — matching how every other container element behaves.
+private struct ListBackgroundModifier: ViewModifier {
+    let node: NativeUINode
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        let darkBg = colorScheme == .dark ? node.props.getColor("dark_bg_color", default: 0) : 0
+        let argb = darkBg != 0 ? darkBg : (node.style?.bgColor ?? 0)
+        if argb != 0 {
+            content
+                .scrollContentBackground(.hidden)
+                .background(Color(argb: argb))
+        } else {
+            content
         }
     }
 }


### PR DESCRIPTION
Two independent iOS renderer gaps, both found by dogfooding a settings screen built on `native:list`:

## 1. List-item rows are mostly tap-dead

`applyClickHandlers` attaches `onTapGesture`, but without a content shape SwiftUI only registers taps on **opaque pixels** — the padding and the `Spacer` gap between the text block and trailing content (i.e. most of the row) do nothing. `@tap` on a `<native:list-item>` effectively required hitting the text exactly; sparse rows felt completely dead. Verified by dumping the wire tree (`on_press` correctly registered) and then reading the renderer.

Fix: `.contentShape(Rectangle())` before the click handlers — the whole row bounds becomes hittable. Android is unaffected (Compose `.clickable` covers full bounds).

Note: the mail demo's `@tap="open(...)"` rows have the same latent issue — dense rows just make lucky hits more common.

## 2. `List` ignores the app theme background

SwiftUI's `List` paints `systemGroupedBackground` and ignores the node's own background style, so `<native:list class="bg-theme-background">` rendered on the stock iOS gray — visibly off-palette in dark mode. Fix: when the node declares a background, `.scrollContentBackground(.hidden)` + paint the node's resolved color (light/dark variant, same resolution as `NodeStyleModifier`). Lists without a declared background keep the stock appearance.

Verified in a themed app in both modes (background pixel-checked against the theme token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)