### PR TITLE
Background layer: persistent content beneath every screen

### DIFF
--- a/nativephp.json
+++ b/nativephp.json
@@ -460,6 +460,14 @@
             "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
             "ios_renderer": "NativeUIEmptyRenderer",
             "self_closing": false
+        },
+        {
+            "type": "background_layer",
+            "element": "Native\\Mobile\\UI\\Elements\\BackgroundLayer",
+            "blade": "Native\\Mobile\\UI\\Components\\BackgroundLayer",
+            "android_renderer": "com.nativephp.plugins.native_ui.ui.EmptyRenderer",
+            "ios_renderer": "NativeUIEmptyRenderer",
+            "self_closing": false
         }
     ],
     "bridge_functions": [

--- a/resources/android/NativeUIBackgroundLayerHost.kt
+++ b/resources/android/NativeUIBackgroundLayerHost.kt
@@ -1,0 +1,56 @@
+package com.nativephp.plugins.native_ui.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import com.nativephp.mobile.ui.nativerender.LocalBackgroundLayerPresent
+import com.nativephp.mobile.ui.nativerender.NativeRendererRegistry
+import com.nativephp.mobile.ui.nativerender.NativeUINode
+import com.nativephp.mobile.ui.nativerender.NodeView
+
+/**
+ * Renders the `background_layer` sentinel BENEATH the screen content —
+ * Compose counterpart of the iOS host. The layer's child sits at a fixed
+ * structural position, so `remember`ed state inside its renderer (a
+ * MapLibre MapView, a player) survives every publish: tab switches and
+ * pushes update props in place instead of recreating the native view.
+ *
+ * Provides [LocalBackgroundLayerPresent] so opaque chrome (the tabs
+ * Scaffold) knows to go transparent above the layer.
+ */
+@Composable
+fun NativeUIBackgroundLayerHost(
+    layerNode: NativeUINode?,
+    content: @Composable () -> Unit,
+) {
+    val child = layerNode?.children?.firstOrNull()
+
+    if (child == null) {
+        content()
+        return
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        // TEMP BISECT: content FIRST (map on top) to test input routing.
+        CompositionLocalProvider(LocalBackgroundLayerPresent provides true) {
+            content()
+        }
+        // Dispatch the layer's renderer DIRECTLY instead of via NodeView:
+        // NodeView wraps children in key(node.id), and flat-buffer ids
+        // shift whenever the tree's shape changes (every navigation) —
+        // which would discard the subtree and recreate the native view.
+        // Direct dispatch keys the renderer to THIS stable call site, so
+        // its remembered state (a MapView, a player) survives any publish.
+        // The layer needs no gesture/style modifier chain, so skipping
+        // NodeView loses nothing.
+        val renderer = NativeRendererRegistry.get(child.type)
+        if (renderer != null) {
+            renderer.Render(child, Modifier.fillMaxSize())
+        } else {
+            NodeView(node = child, overrideModifier = Modifier.fillMaxSize())
+        }
+
+    }
+}

--- a/resources/android/NativeUIBackgroundLayerHost.kt
+++ b/resources/android/NativeUIBackgroundLayerHost.kt
@@ -33,10 +33,6 @@ fun NativeUIBackgroundLayerHost(
     }
 
     Box(Modifier.fillMaxSize()) {
-        // TEMP BISECT: content FIRST (map on top) to test input routing.
-        CompositionLocalProvider(LocalBackgroundLayerPresent provides true) {
-            content()
-        }
         // Dispatch the layer's renderer DIRECTLY instead of via NodeView:
         // NodeView wraps children in key(node.id), and flat-buffer ids
         // shift whenever the tree's shape changes (every navigation) —
@@ -52,5 +48,10 @@ fun NativeUIBackgroundLayerHost(
             NodeView(node = child, overrideModifier = Modifier.fillMaxSize())
         }
 
+        // Content composes SECOND — Compose draws later Box children on
+        // top, which is what keeps the layer beneath the screen.
+        CompositionLocalProvider(LocalBackgroundLayerPresent provides true) {
+            content()
+        }
     }
 }

--- a/resources/android/NativeUIChromeInit.kt
+++ b/resources/android/NativeUIChromeInit.kt
@@ -34,11 +34,7 @@ fun registerNativeUIChrome(context: Context) {
 
     NativeRootHostRegistry.register("native-ui.background-layer", consumes = "background_layer") { root, content ->
         val layerNode = root.children.firstOrNull { it.type == "background_layer" }
-        NativeUIBackgroundLayerHost(
-            layerNode = layerNode,
-            hostedByChrome = root.type == "native_root_tabs",
-            content = content,
-        )
+        NativeUIBackgroundLayerHost(layerNode = layerNode, content = content)
     }
 
     // Supply the app's color scheme from native-ui's theme tokens. The lambda

--- a/resources/android/NativeUIChromeInit.kt
+++ b/resources/android/NativeUIChromeInit.kt
@@ -6,6 +6,7 @@ import com.nativephp.mobile.ui.NativeUIThemeProvider
 import com.nativephp.mobile.ui.nativerender.NativeRootHostRegistry
 import com.nativephp.plugins.native_ui.ui.NativeFloatingOverlayHost
 import com.nativephp.plugins.native_ui.ui.NativeLayoutDrawerHost
+import com.nativephp.plugins.native_ui.ui.NativeUIBackgroundLayerHost
 import com.nativephp.plugins.native_ui.ui.NativeUIFontResolver
 import com.nativephp.plugins.native_ui.ui.nuiThemeDefaultTypography
 
@@ -29,6 +30,15 @@ fun registerNativeUIChrome(context: Context) {
     NativeRootHostRegistry.register("native-ui.floating-overlay", consumes = "floating_overlay") { root, content ->
         val overlayNode = root.children.firstOrNull { it.type == "floating_overlay" }
         NativeFloatingOverlayHost(overlayNode = overlayNode, content = content)
+    }
+
+    NativeRootHostRegistry.register("native-ui.background-layer", consumes = "background_layer") { root, content ->
+        val layerNode = root.children.firstOrNull { it.type == "background_layer" }
+        NativeUIBackgroundLayerHost(
+            layerNode = layerNode,
+            hostedByChrome = root.type == "native_root_tabs",
+            content = content,
+        )
     }
 
     // Supply the app's color scheme from native-ui's theme tokens. The lambda

--- a/resources/ios/NativeUIBackgroundLayerHost.swift
+++ b/resources/ios/NativeUIBackgroundLayerHost.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// Renders the `background_layer` sentinel BENEATH the screen content — the
+/// counterpart of the floating overlay's top layer. The layer's child sits
+/// at a fixed structural position in this view, so SwiftUI keeps its state
+/// objects (a map's camera model, a video player) alive across publishes:
+/// tab switches and pushes update the layer's props in place instead of
+/// re-creating the native view. That's the whole point — a Flighty-style
+/// map behind the app that never reloads.
+///
+/// When `layerNode` is nil this is a transparent pass-through, so it's safe
+/// to wrap every tree unconditionally.
+struct NativeUIBackgroundLayerHost<Content: View>: View {
+    let layerNode: NativeUINode?
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        if let layerNode, let child = layerNode.children.first {
+            ZStack {
+                // Fixed structural position — identity survives republish.
+                NodeView(node: child)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .ignoresSafeArea()
+
+                content
+            }
+        } else {
+            content
+        }
+    }
+}

--- a/resources/ios/NativeUIDrawerHost.swift
+++ b/resources/ios/NativeUIDrawerHost.swift
@@ -16,6 +16,11 @@ func registerNativeUIChrome() {
         return AnyView(NativeFloatingOverlayHost(overlayNode: overlayNode) { content })
     }
 
+    NativeRootHostRegistry.shared.register("native-ui.background-layer", consumes: "background_layer") { root, content in
+        let layerNode = root.children.first { $0.type == "background_layer" }
+        return AnyView(NativeUIBackgroundLayerHost(layerNode: layerNode) { content })
+    }
+
     // Resolve chrome font tokens (per-layout / per-bar `font_name` props on
     // the root sentinels) for core's chrome renderers — bundle lookup +
     // CoreText registration + PostScript naming is this plugin's knowledge.

--- a/src/Builders/BackgroundLayer.php
+++ b/src/Builders/BackgroundLayer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Native\Mobile\UI\Builders;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\Element;
+
+/**
+ * Fluent builder for a persistent background layer — content rendered
+ * BENEATH every screen routed under the layout, mounted once at the
+ * root so it survives tab switches and pushes. The canonical use is a
+ * full-screen map behind a pane (Flighty/Maps-style apps): screens swap
+ * above it while the map keeps its camera, tiles, and gesture state.
+ *
+ *   use Native\Mobile\UI\Builders\BackgroundLayer;
+ *   use Native\Mobile\UI\Concerns\HasBackgroundLayer;
+ *
+ *   class AppLayout extends NativeLayout
+ *   {
+ *       use HasBackgroundLayer;
+ *
+ *       public function backgroundLayer(NativeComponent $screen): ?BackgroundLayer
+ *       {
+ *           return BackgroundLayer::make(view('native.map_layer', $screen->mapPayload()));
+ *       }
+ *   }
+ *
+ * The method re-evaluates on every publish from the current `$screen`,
+ * so the layer's content can be driven by screen state — the NATIVE
+ * side updates the existing mounted view in place rather than
+ * recreating it.
+ */
+class BackgroundLayer
+{
+    protected function __construct(
+        protected View|Element $content,
+    ) {}
+
+    public static function make(View|Element $content): static
+    {
+        return new static($content);
+    }
+
+    public function getContent(): View|Element
+    {
+        return $this->content;
+    }
+}

--- a/src/Components/BackgroundLayer.php
+++ b/src/Components/BackgroundLayer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Native\Mobile\UI\Components;
+
+use Native\Mobile\Edge\Components\Native\NativeBladeComponent;
+
+/**
+ * Blade component for the `background_layer` sentinel — exists to satisfy
+ * the manifest's element/blade pairing; the layer is normally emitted by
+ * the chrome contributor (see HasBackgroundLayer), not written by hand.
+ */
+class BackgroundLayer extends NativeBladeComponent
+{
+    protected function elementType(): string
+    {
+        return 'background_layer';
+    }
+}

--- a/src/Concerns/HasBackgroundLayer.php
+++ b/src/Concerns/HasBackgroundLayer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Native\Mobile\UI\Concerns;
+
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\UI\Builders\BackgroundLayer;
+
+/**
+ * Add a persistent background layer (content beneath every screen, mounted
+ * once — a map, a video, a live canvas) to a `NativeLayout`.
+ *
+ * `use` this trait on a layout and override `backgroundLayer()`; return
+ * null for none. Because it lives on the layout, the layer persists across
+ * every screen routed under that layout — tab switches and pushes update
+ * its props in place instead of recreating the native view.
+ */
+trait HasBackgroundLayer
+{
+    public function backgroundLayer(NativeComponent $screen): ?BackgroundLayer
+    {
+        return null;
+    }
+}

--- a/src/Concerns/InteractsWithBackgroundLayer.php
+++ b/src/Concerns/InteractsWithBackgroundLayer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Native\Mobile\UI\Concerns;
+
+use Native\Mobile\UI\Builders\BackgroundLayer;
+
+/**
+ * Per-screen control over the layout's background layer. `use` this trait on
+ * a `NativeComponent` screen to override or suppress the layer its layout
+ * declares via {@see HasBackgroundLayer}.
+ *
+ *   class SettingsScreen extends NativeComponent
+ *   {
+ *       use InteractsWithBackgroundLayer;
+ *
+ *       // Hide the app-wide map on this screen:
+ *       protected bool $hidesBackgroundLayer = true;
+ *   }
+ *
+ * Or replace it just for this screen:
+ *
+ *   public function backgroundLayerOverride(): ?BackgroundLayer
+ *   {
+ *       return BackgroundLayer::make(view('native.settings_backdrop'));
+ *   }
+ *
+ * Mirrors {@see InteractsWithFloatingOverlay}. The native-ui chrome
+ * contributor checks these (via `method_exists`) before falling back to the
+ * layout. A bare `protected bool $hidesBackgroundLayer = true;` property
+ * WITHOUT this trait also works — the contributor falls back to reading the
+ * property directly, matching core's `$hidesTabBar` / `$hidesNavBar`
+ * shorthand.
+ */
+trait InteractsWithBackgroundLayer
+{
+    /**
+     * Suppress the layout's background layer on this screen. Default `false`
+     * → the layout's `backgroundLayer()` (if any) shows.
+     */
+    protected bool $hidesBackgroundLayer = false;
+
+    /**
+     * Override to provide a per-screen layer that wins over the layout's
+     * `backgroundLayer()`. Returning null falls back to the layout.
+     */
+    public function backgroundLayerOverride(): ?BackgroundLayer
+    {
+        return null;
+    }
+
+    /** Whether this screen suppresses its layout's background layer. */
+    public function hidesBackgroundLayer(): bool
+    {
+        return $this->hidesBackgroundLayer;
+    }
+}

--- a/src/Elements/BackgroundLayer.php
+++ b/src/Elements/BackgroundLayer.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Native\Mobile\UI\Elements;
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+
+/**
+ * Sentinel element produced by the background-layer chrome contributor.
+ * Core appends it to the published tree; the native host — registered on
+ * core's `NativeRootHostRegistry` — pulls it out and renders it BENEATH
+ * the screen content at a stable structural position, so whatever lives
+ * in the layer (a map, a video, a canvas) mounts once and persists
+ * across tab switches and pushes instead of re-initializing per screen.
+ *
+ * Content-agnostic: its single child is an arbitrary rendered
+ * Blade/element tree.
+ */
+class BackgroundLayer extends Element
+{
+    protected string $type = 'background_layer';
+
+    protected array $props = [];
+
+    public static function make(): static
+    {
+        return new static;
+    }
+
+    protected function resolveProps(CallbackRegistry $registry): array
+    {
+        return $this->props;
+    }
+}

--- a/src/NativeUIServiceProvider.php
+++ b/src/NativeUIServiceProvider.php
@@ -158,48 +158,6 @@ class NativeUIServiceProvider extends ServiceProvider
      * {@see InteractsWithFloatingOverlay} traits (or
      * by declaring the methods themselves) — core never knows.
      */
-    /**
-     * Register the background-layer chrome contributor: content rendered
-     * BENEATH every screen under the layout, mounted once at the root so
-     * a map/video/canvas persists across tab switches and pushes. Same
-     * discovery shape as the floating overlay: layouts opt in with
-     * {@see HasBackgroundLayer}, screens can
-     * override via `backgroundLayerOverride()` or hide with
-     * `hidesBackgroundLayer`.
-     */
-    protected function registerBackgroundLayer(): void
-    {
-        if (! class_exists(ChromeContributorRegistry::class)) {
-            return;
-        }
-
-        ChromeContributorRegistry::register(function (NativeComponent $screen, ?NativeLayout $layout, callable $renderPartial): ?Element {
-            if (self::screenHides($screen, 'hidesBackgroundLayer')) {
-                return null;
-            }
-
-            $builder = null;
-            if (method_exists($screen, 'backgroundLayerOverride')) {
-                $builder = $screen->backgroundLayerOverride();
-            }
-            if ($builder === null && $layout !== null && method_exists($layout, 'backgroundLayer')) {
-                $builder = $layout->backgroundLayer($screen);
-            }
-
-            if (! $builder instanceof BackgroundLayer) {
-                return null;
-            }
-
-            $content = $builder->getContent();
-            $contentElement = $content instanceof View ? $renderPartial($content) : $content;
-
-            $sentinel = Elements\BackgroundLayer::make();
-            $sentinel->addChild($contentElement);
-
-            return $sentinel;
-        });
-    }
-
     protected function registerFloatingOverlay(): void
     {
         if (! class_exists(ChromeContributorRegistry::class)) {
@@ -234,6 +192,48 @@ class NativeUIServiceProvider extends ServiceProvider
             $overlay->addChild($contentElement);
 
             return $overlay;
+        });
+    }
+
+    /**
+     * Register the background-layer chrome contributor: content rendered
+     * BENEATH every screen under the layout, mounted once at the root so
+     * a map/video/canvas persists across tab switches and pushes. Same
+     * discovery shape as the floating overlay: layouts opt in with
+     * {@see HasBackgroundLayer}, screens can override via
+     * `backgroundLayerOverride()` or hide with `hidesBackgroundLayer`
+     * (see {@see InteractsWithBackgroundLayer}).
+     */
+    protected function registerBackgroundLayer(): void
+    {
+        if (! class_exists(ChromeContributorRegistry::class)) {
+            return;
+        }
+
+        ChromeContributorRegistry::register(function (NativeComponent $screen, ?NativeLayout $layout, callable $renderPartial): ?Element {
+            if (self::screenHides($screen, 'hidesBackgroundLayer')) {
+                return null;
+            }
+
+            $builder = null;
+            if (method_exists($screen, 'backgroundLayerOverride')) {
+                $builder = $screen->backgroundLayerOverride();
+            }
+            if ($builder === null && $layout !== null && method_exists($layout, 'backgroundLayer')) {
+                $builder = $layout->backgroundLayer($screen);
+            }
+
+            if (! $builder instanceof BackgroundLayer) {
+                return null;
+            }
+
+            $content = $builder->getContent();
+            $contentElement = $content instanceof View ? $renderPartial($content) : $content;
+
+            $sentinel = Elements\BackgroundLayer::make();
+            $sentinel->addChild($contentElement);
+
+            return $sentinel;
         });
     }
 

--- a/src/NativeUIServiceProvider.php
+++ b/src/NativeUIServiceProvider.php
@@ -10,8 +10,10 @@ use Native\Mobile\Edge\Layouts\NativeLayout;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\TailwindParser;
 use Native\Mobile\Testing\TestableComponent;
+use Native\Mobile\UI\Builders\BackgroundLayer;
 use Native\Mobile\UI\Builders\Drawer;
 use Native\Mobile\UI\Builders\FloatingOverlay as FloatingOverlayBuilder;
+use Native\Mobile\UI\Concerns\HasBackgroundLayer;
 use Native\Mobile\UI\Concerns\HasFloatingOverlay;
 use Native\Mobile\UI\Concerns\InteractsWithFloatingOverlay;
 use Native\Mobile\UI\Console\CopyFontsCommand;
@@ -161,7 +163,7 @@ class NativeUIServiceProvider extends ServiceProvider
      * BENEATH every screen under the layout, mounted once at the root so
      * a map/video/canvas persists across tab switches and pushes. Same
      * discovery shape as the floating overlay: layouts opt in with
-     * {@see \Native\Mobile\UI\Concerns\HasBackgroundLayer}, screens can
+     * {@see HasBackgroundLayer}, screens can
      * override via `backgroundLayerOverride()` or hide with
      * `hidesBackgroundLayer`.
      */
@@ -184,14 +186,14 @@ class NativeUIServiceProvider extends ServiceProvider
                 $builder = $layout->backgroundLayer($screen);
             }
 
-            if (! $builder instanceof \Native\Mobile\UI\Builders\BackgroundLayer) {
+            if (! $builder instanceof BackgroundLayer) {
                 return null;
             }
 
             $content = $builder->getContent();
             $contentElement = $content instanceof View ? $renderPartial($content) : $content;
 
-            $sentinel = \Native\Mobile\UI\Elements\BackgroundLayer::make();
+            $sentinel = Elements\BackgroundLayer::make();
             $sentinel->addChild($contentElement);
 
             return $sentinel;

--- a/src/NativeUIServiceProvider.php
+++ b/src/NativeUIServiceProvider.php
@@ -83,6 +83,7 @@ class NativeUIServiceProvider extends ServiceProvider
 
         $this->registerLayoutDrawer();
         $this->registerFloatingOverlay();
+        $this->registerBackgroundLayer();
 
         if ($this->app->runningInConsole()) {
             $this->commands([
@@ -155,6 +156,48 @@ class NativeUIServiceProvider extends ServiceProvider
      * {@see InteractsWithFloatingOverlay} traits (or
      * by declaring the methods themselves) — core never knows.
      */
+    /**
+     * Register the background-layer chrome contributor: content rendered
+     * BENEATH every screen under the layout, mounted once at the root so
+     * a map/video/canvas persists across tab switches and pushes. Same
+     * discovery shape as the floating overlay: layouts opt in with
+     * {@see \Native\Mobile\UI\Concerns\HasBackgroundLayer}, screens can
+     * override via `backgroundLayerOverride()` or hide with
+     * `hidesBackgroundLayer`.
+     */
+    protected function registerBackgroundLayer(): void
+    {
+        if (! class_exists(ChromeContributorRegistry::class)) {
+            return;
+        }
+
+        ChromeContributorRegistry::register(function (NativeComponent $screen, ?NativeLayout $layout, callable $renderPartial): ?Element {
+            if (self::screenHides($screen, 'hidesBackgroundLayer')) {
+                return null;
+            }
+
+            $builder = null;
+            if (method_exists($screen, 'backgroundLayerOverride')) {
+                $builder = $screen->backgroundLayerOverride();
+            }
+            if ($builder === null && $layout !== null && method_exists($layout, 'backgroundLayer')) {
+                $builder = $layout->backgroundLayer($screen);
+            }
+
+            if (! $builder instanceof \Native\Mobile\UI\Builders\BackgroundLayer) {
+                return null;
+            }
+
+            $content = $builder->getContent();
+            $contentElement = $content instanceof View ? $renderPartial($content) : $content;
+
+            $sentinel = \Native\Mobile\UI\Elements\BackgroundLayer::make();
+            $sentinel->addChild($contentElement);
+
+            return $sentinel;
+        });
+    }
+
     protected function registerFloatingOverlay(): void
     {
         if (! class_exists(ChromeContributorRegistry::class)) {

--- a/tests/BackgroundLayerTest.php
+++ b/tests/BackgroundLayerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\UI\Builders\BackgroundLayer as BackgroundLayerBuilder;
+use Native\Mobile\UI\Concerns\InteractsWithBackgroundLayer;
+use Native\Mobile\UI\Elements\BackgroundLayer;
+use Native\Mobile\UI\Elements\Chip;
+use Native\Mobile\UI\NativeUIServiceProvider;
+
+/**
+ * The background-layer layout hook: persistent content rendered beneath
+ * every screen under the layout (a map, a video, a canvas). Covers the
+ * builder surface (returned from `NativeLayout::backgroundLayer()`) and
+ * the `background_layer` sentinel the chrome contributor emits from it.
+ * Mirrors FloatingOverlayTest.
+ */
+it('carries content through the builder', function () {
+    $content = Chip::make('Map layer');
+    $builder = BackgroundLayerBuilder::make($content);
+
+    expect($builder->getContent())->toBe($content);
+});
+
+it('serializes the sentinel with its child beneath it', function () {
+    $sentinel = BackgroundLayer::make();
+    $sentinel->addChild(Chip::make('Map layer'));
+
+    $tree = $sentinel->toArray(new CallbackRegistry);
+
+    expect($tree['type'])->toBe('background_layer');
+    expect($tree['children'])->toHaveCount(1);
+    expect($tree['children'][0]['type'])->toBe('chip');
+});
+
+/**
+ * The contributor's per-screen opt-out accepts BOTH spellings: the
+ * InteractsWithBackgroundLayer trait (method form) and a bare
+ * `protected bool $hidesBackgroundLayer = true;` property — the latter
+ * matching core's `$hidesTabBar` / `$hidesNavBar` shorthand.
+ */
+it('reads the background-layer opt-out from the trait method form', function () {
+    $screen = new class extends NativeComponent
+    {
+        use InteractsWithBackgroundLayer;
+
+        public function __construct()
+        {
+            $this->hidesBackgroundLayer = true;
+        }
+    };
+
+    expect(NativeUIServiceProvider::screenHides($screen, 'hidesBackgroundLayer'))->toBeTrue();
+});
+
+it('reads the background-layer opt-out from a bare property without the trait', function () {
+    $screen = new class extends NativeComponent
+    {
+        protected bool $hidesBackgroundLayer = true;
+    };
+
+    expect(NativeUIServiceProvider::screenHides($screen, 'hidesBackgroundLayer'))->toBeTrue();
+});
+
+it('defaults the background-layer opt-out to false when the screen declares neither', function () {
+    $screen = new class extends NativeComponent {};
+
+    expect(NativeUIServiceProvider::screenHides($screen, 'hidesBackgroundLayer'))->toBeFalse();
+});
+
+it('the trait override hook defaults to null so the layout wins', function () {
+    $screen = new class extends NativeComponent
+    {
+        use InteractsWithBackgroundLayer;
+    };
+
+    expect($screen->backgroundLayerOverride())->toBeNull();
+});


### PR DESCRIPTION
A chrome contributor + native root hosts that render arbitrary content (a map, a video, a canvas) **beneath** the screen content at a stable structural position — mounted once at the root, so it persists across tab switches and pushes instead of re-initializing per screen.

- Discovery mirrors the floating overlay: layouts opt in with `HasBackgroundLayer` / a `backgroundLayer()` builder; screens override via `backgroundLayerOverride()` or hide with `hidesBackgroundLayer`.
- The `background_layer` sentinel element travels in the published tree; iOS (`NativeUIBackgroundLayerHost.swift`) and Android (`NativeUIBackgroundLayerHost.kt`) hosts registered on core's `NativeRootHostRegistry` pull it out and compose it under the content (tabs-hosted variant handled on Android).

Draft — in-flight feature branch packaged from the working tree so it has a home; review/finish at leisure.