### PR TITLE
Fix Android compile against cores without the background-layer transparency local

### DIFF
--- a/resources/android/NativeUIBackgroundLayerHost.kt
+++ b/resources/android/NativeUIBackgroundLayerHost.kt
@@ -3,9 +3,7 @@ package com.nativephp.plugins.native_ui.ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import com.nativephp.mobile.ui.nativerender.LocalBackgroundLayerPresent
 import com.nativephp.mobile.ui.nativerender.NativeRendererRegistry
 import com.nativephp.mobile.ui.nativerender.NativeUINode
 import com.nativephp.mobile.ui.nativerender.NodeView
@@ -17,8 +15,12 @@ import com.nativephp.mobile.ui.nativerender.NodeView
  * MapLibre MapView, a player) survives every publish: tab switches and
  * pushes update props in place instead of recreating the native view.
  *
- * Provides [LocalBackgroundLayerPresent] so opaque chrome (the tabs
- * Scaffold) knows to go transparent above the layer.
+ * NOTE: this file must compile against every core this plugin installs
+ * into — it must not reference core symbols that only exist on newer
+ * cores. The `LocalBackgroundLayerPresent` transparency signal (so the
+ * tabs Scaffold can go transparent above the layer) returns here once
+ * the distributed core ships that composition local alongside the
+ * tabs-hosting work.
  */
 @Composable
 fun NativeUIBackgroundLayerHost(
@@ -50,8 +52,6 @@ fun NativeUIBackgroundLayerHost(
 
         // Content composes SECOND — Compose draws later Box children on
         // top, which is what keeps the layer beneath the screen.
-        CompositionLocalProvider(LocalBackgroundLayerPresent provides true) {
-            content()
-        }
+        content()
     }
 }


### PR DESCRIPTION
## What

#37's Android host hard-referenced `LocalBackgroundLayerPresent`, a composition local that only exists in the dev core (super-native-web) — not in the distributed core (mobile-air). Since plugin Kotlin compiles into the app module of every install, that single unresolved reference broke `compileDebugKotlin` for **every app** on mobile-ui dev-main + mobile-air dev-main, background layer used or not (first hit in a real app within hours of merging).

The host now renders the layer beneath content without providing the transparency signal, and carries a NOTE that plugin sources must not reference core symbols absent from cores the plugin installs into. The signal returns once the distributed core ships the local alongside the tabs-hosting work.

Verified: `LocalBackgroundLayerPresent` was the only cross-core symbol gap — every other symbol the #37/#38 plugin files reference (NativeRootHostRegistry on both platforms, `NodeView(overrideModifier:)`, `NativeRendererRegistry`, `sendTextChangeEvent`) exists in mobile-air dev-main.

## Follow-up

The structural fix (also noted on #37) is a core-version gate in the plugin manifest so install-time mismatches fail loudly instead of at Kotlin compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)