### PR TITLE
Restore the background-layer transparency provider (requires mobile-air#287)

### DIFF
--- a/resources/android/NativeUIBackgroundLayerHost.kt
+++ b/resources/android/NativeUIBackgroundLayerHost.kt
@@ -3,7 +3,9 @@ package com.nativephp.plugins.native_ui.ui
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import com.nativephp.mobile.ui.nativerender.LocalBackgroundLayerPresent
 import com.nativephp.mobile.ui.nativerender.NativeRendererRegistry
 import com.nativephp.mobile.ui.nativerender.NativeUINode
 import com.nativephp.mobile.ui.nativerender.NodeView
@@ -15,12 +17,12 @@ import com.nativephp.mobile.ui.nativerender.NodeView
  * MapLibre MapView, a player) survives every publish: tab switches and
  * pushes update props in place instead of recreating the native view.
  *
- * NOTE: this file must compile against every core this plugin installs
- * into — it must not reference core symbols that only exist on newer
- * cores. The `LocalBackgroundLayerPresent` transparency signal (so the
- * tabs Scaffold can go transparent above the layer) returns here once
- * the distributed core ships that composition local alongside the
- * tabs-hosting work.
+ * Provides [LocalBackgroundLayerPresent] so opaque chrome (the tabs
+ * Scaffold) knows to go transparent above the layer. NOTE: plugin
+ * sources compile into the app module, so every core symbol referenced
+ * here must exist in the distributed core — the local ships in
+ * mobile-air as of NativePHP/mobile-air#287; this plugin requires a
+ * core at or past it.
  */
 @Composable
 fun NativeUIBackgroundLayerHost(
@@ -52,6 +54,8 @@ fun NativeUIBackgroundLayerHost(
 
         // Content composes SECOND — Compose draws later Box children on
         // top, which is what keeps the layer beneath the screen.
-        content()
+        CompositionLocalProvider(LocalBackgroundLayerPresent provides true) {
+            content()
+        }
     }
 }


### PR DESCRIPTION
Re-provides `LocalBackgroundLayerPresent` around screen content in the Android background-layer host, restoring the tabs-Scaffold transparency signal that #40 temporarily removed. The distributed core ships the composition local and its Scaffold consumption as of NativePHP/mobile-air#287 — **do not merge this before #287 is on mobile-air main**, or Android compiles break again for apps on the distributed core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)