### PR TITLE
fix(ios): multiline inputs must insert a newline on every keyboard

### DIFF
--- a/resources/ios/NativeUITextInputCore.swift
+++ b/resources/ios/NativeUITextInputCore.swift
@@ -8,8 +8,9 @@ import UIKit
 ///     value we sent out)
 ///   - `sync_mode` dispatch policy (live | debounce | blur) — controlled by
 ///     the `native:model` directive modifier chain
-///   - secure / multiline input
-///   - keyboard type, submit label
+///   - secure input; multiline input (TextEditor-backed — the return key
+///     always inserts a line break, so submit is send-button-only there)
+///   - keyboard type, submit label (single-line only)
 ///   - disabled / readOnly state
 ///   - onChange / onSubmit callbacks
 ///
@@ -87,7 +88,7 @@ struct NativeUITextInputCore: View {
         // text adopts `contentColor`. SwiftUI's TextField/SecureField don't
         // reliably pick up `.foregroundStyle` for the input text on older
         // iOS runtimes — `.foregroundColor` on the field itself always works.
-        Group {
+        let core = Group {
             if secure {
                 // SecureField has no selection binding — caret reporting is
                 // intentionally never available for secure fields.
@@ -95,31 +96,58 @@ struct NativeUITextInputCore: View {
                     .foregroundColor(contentColor)
                     .focused($isFocused)
             } else if multiline {
-                // A vertical-axis TextField reports a ~0 intrinsic width when
-                // empty and won't expand to fill an ancestor's `maxWidth:
-                // .infinity` the way a single-line field does — so without this
-                // explicit fill it collapses to its content (just the icon).
-                // `min-lines` reserves visible height up front (a textarea
-                // that LOOKS like a textarea before you type); `max-lines`
-                // caps growth. Clamp so a min above the max still renders.
+                // NOT a vertical-axis TextField: with a hardware keyboard
+                // (simulator typed from the Mac keyboard, iPad + external
+                // keyboard) Return UNFOCUSES a vertical TextField instead of
+                // inserting a newline — confirmed as-designed by Apple DTS
+                // (developer.apple.com/forums/thread/760511). TextEditor's
+                // return key inserts a line break on every keyboard.
+                //
+                // The invisible Text mirror re-creates the auto-growing
+                // `lineLimit(min...max)` window the vertical TextField had:
+                // it sizes the branch (the trailing space keeps a just-typed
+                // empty last line measurable — Text collapses a trailing
+                // newline on its own), and the editor fills the overlay.
                 let lower = max(minLines, 1)
                 let upper = maxLines > 0 ? max(maxLines, lower) : max(5, lower)
-                // The iOS 18 `selection:` binding is honored on the vertical
-                // (multiline) axis too. Kept as parallel branches so the
-                // feature-off path is byte-for-byte the original field.
-                if selectionEnabled {
-                    TextField(placeholder, text: $text, selection: $selection, axis: .vertical)
-                        .lineLimit(lower...upper)
+                Text(text + " ")
+                    .lineLimit(lower...upper)
+                    .opacity(0)
+                    // Sizing-only: without this VoiceOver reads the typed
+                    // text twice (mirror + editor).
+                    .accessibilityHidden(true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .overlay {
+                        Group {
+                            // The iOS 18 `selection:` binding exists on
+                            // TextEditor too. Parallel branches so the
+                            // feature-off path carries no selection state.
+                            if selectionEnabled {
+                                TextEditor(text: $text, selection: $selection)
+                            } else {
+                                TextEditor(text: $text)
+                            }
+                        }
+                        // Let the variant chrome paint the background.
+                        .scrollContentBackground(.hidden)
                         .foregroundColor(contentColor)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        // Pull back UITextView's internal text-container
+                        // padding (5pt line-fragment + ~8pt vertical inset)
+                        // so the typed text lines up with the single-line
+                        // variants inside the same chrome — and with the
+                        // sizing mirror above.
+                        .padding(.horizontal, -5)
+                        .padding(.vertical, -8)
                         .focused($isFocused)
-                } else {
-                    TextField(placeholder, text: $text, axis: .vertical)
-                        .lineLimit(lower...upper)
-                        .foregroundColor(contentColor)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .focused($isFocused)
-                }
+                    }
+                    .overlay(alignment: .topLeading) {
+                        // TextEditor has no placeholder slot.
+                        if text.isEmpty && !placeholder.isEmpty {
+                            Text(placeholder)
+                                .foregroundStyle(Color(UIColor.placeholderText))
+                                .allowsHitTesting(false)
+                        }
+                    }
             } else {
                 if selectionEnabled {
                     TextField(placeholder, text: $text, selection: $selection)
@@ -141,7 +169,6 @@ struct NativeUITextInputCore: View {
         .tint(tintColor)
         .keyboardType(keyboard)
         .disabled(disabled || readOnly)
-        .submitLabel(onSubmitCb != 0 ? .done : .return)
         .onAppear {
             if !initialized {
                 text = serverValue
@@ -215,26 +242,40 @@ struct NativeUITextInputCore: View {
                 }
             }
         }
-        .onSubmit {
-            // Submit also acts as a commit point — flush pending, then dispatch.
-            flushPending(onChangeCb: onChangeCb)
-            // Selection is flushed BEFORE the submit event so PHP sees the final
-            // caret/selection state ahead of (or alongside) the submit.
-            if selectionEnabled {
-                flushSelection(cb: onSelectionCb)
-            }
-            if onSubmitCb != 0 {
-                NativeElementBridge.sendSubmitEvent(onSubmitCb, nodeId: node.id, text: text)
-            }
-            // Chat "send and keep typing": SwiftUI resigns first responder on
-            // return by default. Re-assert focus so the keyboard stays up. NOTE:
-            // this causes a small keyboard "bounce" on return (resign → refocus)
-            // that the send button doesn't have — the smooth fix needs a
-            // UIKit-backed field (see notes), not the multiline workaround which
-            // mis-sized the field in the flex layout.
-            if keepFocus {
-                DispatchQueue.main.async { isFocused = true }
-            }
+        // Return-key policy — parity with Android. `.onSubmit` must NOT be
+        // attached to a multiline (vertical-axis) field: the soft keyboard's
+        // return key inserts a newline either way, but with `.onSubmit`
+        // attached a HARDWARE keyboard's Return (simulator typed from the Mac,
+        // iPad + external keyboard) fires the submit path and swallows the
+        // newline. Android multiline behaves the same on purpose: Enter always
+        // inserts a line break and `@submit` is only reachable through a
+        // dedicated send button. Blur still flushes pending changes above.
+        if multiline {
+            core
+        } else {
+            core
+                .submitLabel(onSubmitCb != 0 ? .done : .return)
+                .onSubmit {
+                    // Submit also acts as a commit point — flush pending, then dispatch.
+                    flushPending(onChangeCb: onChangeCb)
+                    // Selection is flushed BEFORE the submit event so PHP sees the final
+                    // caret/selection state ahead of (or alongside) the submit.
+                    if selectionEnabled {
+                        flushSelection(cb: onSelectionCb)
+                    }
+                    if onSubmitCb != 0 {
+                        NativeElementBridge.sendSubmitEvent(onSubmitCb, nodeId: node.id, text: text)
+                    }
+                    // Chat "send and keep typing": SwiftUI resigns first responder on
+                    // return by default. Re-assert focus so the keyboard stays up. NOTE:
+                    // this causes a small keyboard "bounce" on return (resign → refocus)
+                    // that the send button doesn't have — the smooth fix needs a
+                    // UIKit-backed field (see notes), not the multiline workaround which
+                    // mis-sized the field in the flex layout.
+                    if keepFocus {
+                        DispatchQueue.main.async { isFocused = true }
+                    }
+                }
         }
     }
 

--- a/src/Elements/BaseTextInput.php
+++ b/src/Elements/BaseTextInput.php
@@ -268,6 +268,11 @@ abstract class BaseTextInput extends Element
         return $this;
     }
 
+    /**
+     * Multiline: the return/enter key always inserts a line break on both
+     * platforms (never submits), so `@submit` is not reachable from the
+     * keyboard — pair the field with a send/save button instead.
+     */
     public function multiline(bool $value = true): static
     {
         $this->inputProps['multiline'] = $value;


### PR DESCRIPTION
## The bug

On iOS, a `multiline` text input (`<native:outlined-text-input multiline …>`, and the filled/bare variants) never inserts a line break when Return is pressed from a **hardware keyboard** — the simulator driven from the Mac keyboard, or an iPad with an external keyboard. The field silently drops focus instead. Soft (on-screen) keyboards were unaffected. Android has always behaved correctly (Enter inserts a newline).

## Root cause

The multiline branch of `NativeUITextInputCore` was a `TextField(axis: .vertical)`. SwiftUI's vertical-axis `TextField` unfocuses on hardware-keyboard Return **by design** — confirmed by Apple DTS in https://developer.apple.com/forums/thread/760511 — and no modifier combination opts out (`.onKeyPress` interception also unfocuses). Removing `.onSubmit` is not enough.

## The fix

Rebuild the multiline branch on **`TextEditor`** (UITextView-backed), whose return key inserts a line break on every keyboard — the alternative Apple suggests in that thread:

- An invisible `Text` mirror re-creates the auto-growing `lineLimit(min...max)` window the vertical TextField had (same clamps, same default cap of 5 lines); it is `accessibilityHidden` so VoiceOver doesn't read the typed text twice.
- Placeholder recreated as an overlay (`TextEditor` has no placeholder slot), with UITextView's internal container padding pulled back so typed text lines up with the single-line variants inside the same chrome.
- `scrollContentBackground(.hidden)` lets the variant chrome keep painting the background.
- `.submitLabel` / `.onSubmit` now attach to single-line fields only. Multiline Return always inserts a newline and `@submit` is send-button-only — matching what Android multiline (Enter = newline, no keyboard submit) has always done. Documented on `BaseTextInput::multiline()` and in the core's header.

Value sync, echo prevention, the three `sync_mode` policies, `max_length`, keyboard type, disabled/read-only, custom fonts and the iOS 18 `selection:` binding (`@selectionChange`) are unchanged and apply to `TextEditor` as-is. Single-line fields keep a byte-for-byte identical code path. No wire/PHP behavior change; Android untouched.

## Verification

- `swiftc -parse` clean; full simulator build succeeds and the rebuilt app was manually tested: multiline fields accept newlines from both the Mac keyboard (simulator) and the on-screen keyboard; single-line `@submit` + `keep-focus-on-submit` chat pattern unchanged.
- Wire props verified via the Pest harness (`multiline`, `min_lines`, `max_lines` serialize as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)