### PR TITLE
Error display for Select, DatePicker, Checkbox, RadioGroup

### DIFF
--- a/resources/android/CheckboxRenderer.kt
+++ b/resources/android/CheckboxRenderer.kt
@@ -2,10 +2,12 @@ package com.nativephp.plugins.native_ui.ui
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -37,8 +39,15 @@ object CheckboxRenderer {
         val disabled    = p.getBool("disabled")
         val a11yLabel   = p.getString("a11y_label")
         val a11yHint    = p.getString("a11y_hint")
+        val isError     = p.getBool("is_error")
+        val supporting  = p.getString("supporting")
 
         val theme = if (isSystemInDarkTheme()) NativeUITheme.dark else NativeUITheme.light
+
+        // Error state rides the hint channel unless an explicit hint is
+        // set (same convention as the text inputs).
+        val errorText = if (isError && supporting.isNotEmpty()) supporting else ""
+        val effectiveA11yHint = a11yHint.ifEmpty { errorText }
 
         var checked by remember(node.id) { mutableStateOf(serverValue) }
         var lastSentValue by remember(node.id) { mutableStateOf(serverValue) }
@@ -51,8 +60,8 @@ object CheckboxRenderer {
         }
 
         val colors = CheckboxDefaults.colors(
-            checkedColor = theme.primary,
-            uncheckedColor = theme.outline,
+            checkedColor = if (isError) theme.destructive else theme.primary,
+            uncheckedColor = if (isError) theme.destructive else theme.outline,
             checkmarkColor = theme.onPrimary,
             disabledCheckedColor = theme.primary.copy(alpha = 0.38f),
             disabledUncheckedColor = theme.outline.copy(alpha = 0.38f),
@@ -69,26 +78,37 @@ object CheckboxRenderer {
         // toggleable on the row merges descendants into ONE TalkBack focus
         // stop and makes the label itself a tap target; the inner Checkbox
         // gets onCheckedChange = null so there's no nested second target.
-        Row(
-            modifier = modifier
-                .nuiA11y(a11yLabel, a11yHint)
-                .toggleable(
-                    value = checked,
+        Column(modifier = modifier) {
+            Row(
+                modifier = Modifier
+                    .nuiA11y(a11yLabel, effectiveA11yHint)
+                    .toggleable(
+                        value = checked,
+                        enabled = !disabled,
+                        role = Role.Checkbox,
+                        onValueChange = onChanged,
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Checkbox(
+                    checked = checked,
+                    onCheckedChange = null,
                     enabled = !disabled,
-                    role = Role.Checkbox,
-                    onValueChange = onChanged,
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Checkbox(
-                checked = checked,
-                onCheckedChange = null,
-                enabled = !disabled,
-                colors = colors,
-            )
-            if (label.isNotEmpty()) {
-                Text(text = label, fontFamily = nuiDefaultFontFamily(), color = theme.onSurface)
+                    colors = colors,
+                )
+                if (label.isNotEmpty()) {
+                    Text(text = label, fontFamily = nuiDefaultFontFamily(), color = theme.onSurface)
+                }
+            }
+
+            if (supporting.isNotEmpty()) {
+                Text(
+                    text = supporting,
+                    fontFamily = nuiDefaultFontFamily(),
+                    color = if (isError) theme.destructive else theme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
             }
         }
     }

--- a/resources/android/DatePickerRenderer.kt
+++ b/resources/android/DatePickerRenderer.kt
@@ -87,6 +87,8 @@ object DatePickerRenderer {
         val disabled     = p.getBool("disabled")
         val a11yLabel    = p.getString("a11y_label")
         val a11yHint     = p.getString("a11y_hint")
+        val isError      = p.getBool("is_error")
+        val supporting   = p.getString("supporting")
 
         val theme  = if (isSystemInDarkTheme()) NativeUITheme.dark else NativeUITheme.light
         val zone   = resolveZone(p.getString("timezone"))
@@ -159,6 +161,8 @@ object DatePickerRenderer {
                         onValueChange = {},
                         readOnly = true,
                         enabled = !disabled,
+                        isError = isError,
+                        supportingText = supportingSlot(supporting),
                         placeholder = if (placeholder.isNotEmpty()) {
                             { Text(placeholder, fontFamily = nuiDefaultFontFamily()) }
                         } else null,
@@ -172,6 +176,9 @@ object DatePickerRenderer {
                         modifier = Modifier.fillMaxWidth(),
                         textStyle = TextStyle(color = theme.onSurface),
                         colors = OutlinedTextFieldDefaults.colors(
+                            errorBorderColor = theme.destructive,
+                            errorSupportingTextColor = theme.destructive,
+                            errorTrailingIconColor = theme.destructive,
                             focusedTextColor = theme.onSurface,
                             unfocusedTextColor = theme.onSurface,
                             focusedBorderColor = theme.primary,

--- a/resources/android/RadioGroupRenderer.kt
+++ b/resources/android/RadioGroupRenderer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,8 +35,15 @@ object RadioGroupRenderer {
         val groupDisabled = p.getBool("disabled")
         val a11yLabel   = p.getString("a11y_label")
         val a11yHint    = p.getString("a11y_hint")
+        val isError     = p.getBool("is_error")
+        val supporting  = p.getString("supporting")
 
         val theme = if (isSystemInDarkTheme()) NativeUITheme.dark else NativeUITheme.light
+
+        // Error state rides the hint channel unless an explicit hint is
+        // set (same convention as the text inputs).
+        val errorText = if (isError && supporting.isNotEmpty()) supporting else ""
+        val effectiveA11yHint = a11yHint.ifEmpty { errorText }
 
         var selectedValue by remember(node.id) { mutableStateOf(serverValue) }
         var lastSentValue by remember(node.id) { mutableStateOf(serverValue) }
@@ -47,11 +55,11 @@ object RadioGroupRenderer {
             }
         }
 
-        val groupModifier = modifier.nuiA11y(a11yLabel, a11yHint)
+        val groupModifier = modifier.nuiA11y(a11yLabel, effectiveA11yHint)
 
         Column(modifier = groupModifier) {
             if (label.isNotEmpty()) {
-                Text(text = label, fontFamily = nuiDefaultFontFamily(), color = theme.onSurfaceVariant)
+                Text(text = label, fontFamily = nuiDefaultFontFamily(), color = if (isError) theme.destructive else theme.onSurfaceVariant)
                 Spacer(Modifier.height(8.dp))
             }
             node.children.forEach { child ->
@@ -72,6 +80,15 @@ object RadioGroupRenderer {
                 } else {
                     RenderNode(child)
                 }
+            }
+
+            if (supporting.isNotEmpty()) {
+                Text(
+                    text = supporting,
+                    fontFamily = nuiDefaultFontFamily(),
+                    color = if (isError) theme.destructive else theme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodySmall,
+                )
             }
         }
     }

--- a/resources/android/SelectRenderer.kt
+++ b/resources/android/SelectRenderer.kt
@@ -40,6 +40,8 @@ object SelectRenderer {
         val disabled    = p.getBool("disabled")
         val a11yLabel   = p.getString("a11y_label")
         val a11yHint    = p.getString("a11y_hint")
+        val isError     = p.getBool("is_error")
+        val supporting  = p.getString("supporting")
 
         val theme = if (isSystemInDarkTheme()) NativeUITheme.dark else NativeUITheme.light
 
@@ -69,9 +71,15 @@ object SelectRenderer {
                 label = if (label.isNotEmpty()) ({ Text(label, fontFamily = nuiDefaultFontFamily()) }) else null,
                 placeholder = if (placeholder.isNotEmpty()) ({ Text(placeholder, fontFamily = nuiDefaultFontFamily()) }) else null,
                 trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                isError = isError,
+                supportingText = supportingSlot(supporting),
                 modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
                 textStyle = TextStyle(color = theme.onSurface),
                 colors = OutlinedTextFieldDefaults.colors(
+                    errorBorderColor = theme.destructive,
+                    errorLabelColor = theme.destructive,
+                    errorSupportingTextColor = theme.destructive,
+                    errorTrailingIconColor = theme.destructive,
                     focusedTextColor = theme.onSurface,
                     unfocusedTextColor = theme.onSurface,
                     focusedBorderColor = theme.primary,

--- a/resources/ios/NativeUICheckboxRenderer.swift
+++ b/resources/ios/NativeUICheckboxRenderer.swift
@@ -25,7 +25,15 @@ struct NativeUICheckboxRenderer: View {
         let disabled    = p.getBool("disabled")
         let a11yLabel   = p.getString("a11y_label")
         let a11yHint    = p.getString("a11y_hint")
+        let isError     = p.getBool("is_error")
+        let supporting  = p.getString("supporting")
 
+        // Error state rides the hint channel unless an explicit hint is
+        // set (same convention as the text inputs).
+        let errorText = (isError && !supporting.isEmpty) ? supporting : ""
+        let effectiveA11yHint = a11yHint.isEmpty ? errorText : a11yHint
+
+        VStack(alignment: .leading, spacing: 4) {
         Button(action: {
             guard !disabled else { return }
             let new = !checked
@@ -38,7 +46,7 @@ struct NativeUICheckboxRenderer: View {
             HStack(spacing: 8) {
                 Image(systemName: checked ? "checkmark.square.fill" : "square")
                     .nuiScaledFont(size: 22)
-                    .foregroundColor(checked ? theme.primary : theme.onSurfaceVariant)
+                    .foregroundColor(isError ? theme.destructive : (checked ? theme.primary : theme.onSurfaceVariant))
                 if !label.isEmpty {
                     Text(label)
                         .nuiScaledFont(size: 17)
@@ -66,7 +74,14 @@ struct NativeUICheckboxRenderer: View {
         .modifier(A11yToggleTraitModifier())
         .accessibilityValue(checked ? "Checked" : "Unchecked")
         .modifier(A11yLabelModifier(label: a11yLabel))
-        .modifier(A11yHintModifier(hint: a11yHint))
+        .modifier(A11yHintModifier(hint: effectiveA11yHint))
+
+        if !supporting.isEmpty {
+            Text(supporting)
+                .nuiScaledFont(size: theme.fontSm)
+                .foregroundStyle(isError ? theme.destructive : theme.onSurfaceVariant)
+        }
+        }
     }
 }
 

--- a/resources/ios/NativeUIDatePickerRenderer.swift
+++ b/resources/ios/NativeUIDatePickerRenderer.swift
@@ -47,6 +47,13 @@ struct NativeUIDatePickerRenderer: View {
         let disabled    = p.getBool("disabled")
         let a11yLabel   = p.getString("a11y_label")
         let a11yHint    = p.getString("a11y_hint")
+        let isError     = p.getBool("is_error")
+        let supporting  = p.getString("supporting")
+
+        // Error state rides the hint channel unless an explicit hint is
+        // set (same convention as the text inputs).
+        let errorText = (isError && !supporting.isEmpty) ? supporting : ""
+        let effectiveA11yHint = a11yHint.isEmpty ? errorText : a11yHint
 
         let calendar = resolvedCalendar()
         let locale   = resolvedLocale()
@@ -81,7 +88,7 @@ struct NativeUIDatePickerRenderer: View {
                     .padding(.vertical, 11)
                     .background(
                         RoundedRectangle(cornerRadius: theme.radiusMd, style: .continuous)
-                            .stroke(theme.outline, lineWidth: 1)
+                            .stroke(isError ? theme.destructive : theme.outline, lineWidth: 1)
                     )
                 }
                 .disabled(disabled)
@@ -106,6 +113,12 @@ struct NativeUIDatePickerRenderer: View {
                 // value, so a bare a11y-label still announces what's picked.
                 .accessibilityValue(displayString(mode: mode, locale: locale, calendar: calendar))
             }
+
+            if !supporting.isEmpty {
+                Text(supporting)
+                    .nuiScaledFont(size: theme.fontSm)
+                    .foregroundStyle(isError ? theme.destructive : theme.onSurfaceVariant)
+            }
         }
         .onAppear {
             guard !initialized else { return }
@@ -124,7 +137,7 @@ struct NativeUIDatePickerRenderer: View {
             commit(mode: mode, calendar: calendar, onChangeCb: onChangeCb)
         }
         .modifier(NativeUIDatePickerA11yLabel(label: a11yLabel))
-        .modifier(NativeUIDatePickerA11yHint(hint: a11yHint))
+        .modifier(NativeUIDatePickerA11yHint(hint: effectiveA11yHint))
     }
 
     // ── Picker construction ──────────────────────────────────────────────────

--- a/resources/ios/NativeUIRadioGroupRenderer.swift
+++ b/resources/ios/NativeUIRadioGroupRenderer.swift
@@ -22,12 +22,19 @@ struct NativeUIRadioGroupRenderer: View {
         let groupDisabled = node.props.getBool("disabled")
         let a11yLabel   = node.props.getString("a11y_label")
         let a11yHint    = node.props.getString("a11y_hint")
+        let isError     = node.props.getBool("is_error")
+        let supporting  = node.props.getString("supporting")
+
+        // Error state rides the hint channel unless an explicit hint is
+        // set (same convention as the text inputs).
+        let errorText = (isError && !supporting.isEmpty) ? supporting : ""
+        let effectiveA11yHint = a11yHint.isEmpty ? errorText : a11yHint
 
         VStack(alignment: .leading, spacing: 8) {
             if !label.isEmpty {
                 Text(label)
                     .nuiScaledFont(size: theme.fontSm, weight: .medium)
-                    .foregroundStyle(theme.onSurfaceVariant)
+                    .foregroundStyle(isError ? theme.destructive : theme.onSurfaceVariant)
             }
 
             ForEach(node.children.filter { $0.type == "radio" }) { child in
@@ -45,6 +52,12 @@ struct NativeUIRadioGroupRenderer: View {
                     }
                 )
             }
+
+            if !supporting.isEmpty {
+                Text(supporting)
+                    .nuiScaledFont(size: theme.fontSm)
+                    .foregroundStyle(isError ? theme.destructive : theme.onSurfaceVariant)
+            }
         }
         .onAppear {
             if !initialized {
@@ -60,7 +73,7 @@ struct NativeUIRadioGroupRenderer: View {
             }
         }
         .modifier(A11yLabelModifier(label: a11yLabel))
-        .modifier(A11yHintModifier(hint: a11yHint))
+        .modifier(A11yHintModifier(hint: effectiveA11yHint))
     }
 }
 

--- a/resources/ios/NativeUISelectRenderer.swift
+++ b/resources/ios/NativeUISelectRenderer.swift
@@ -25,6 +25,14 @@ struct NativeUISelectRenderer: View {
         let disabled    = p.getBool("disabled")
         let a11yLabel   = p.getString("a11y_label")
         let a11yHint    = p.getString("a11y_hint")
+        let isError     = p.getBool("is_error")
+        let supporting  = p.getString("supporting")
+
+        // Error state must be announced, not just tinted: the supporting
+        // text rides the hint channel unless an explicit hint is set
+        // (same convention as the text inputs).
+        let errorText = (isError && !supporting.isEmpty) ? supporting : ""
+        let effectiveA11yHint = a11yHint.isEmpty ? errorText : a11yHint
 
         VStack(alignment: .leading, spacing: 4) {
             if !label.isEmpty {
@@ -56,7 +64,7 @@ struct NativeUISelectRenderer: View {
                 .padding(.vertical, 11)
                 .background(
                     RoundedRectangle(cornerRadius: theme.radiusMd, style: .continuous)
-                        .stroke(theme.outline, lineWidth: 1)
+                        .stroke(isError ? theme.destructive : theme.outline, lineWidth: 1)
                 )
             }
             .disabled(disabled)
@@ -64,6 +72,12 @@ struct NativeUISelectRenderer: View {
             // Announce the current selection as the control's value so
             // VoiceOver reads "…, <selected option>" on focus.
             .accessibilityValue(selected)
+
+            if !supporting.isEmpty {
+                Text(supporting)
+                    .nuiScaledFont(size: theme.fontSm)
+                    .foregroundStyle(isError ? theme.destructive : theme.onSurfaceVariant)
+            }
         }
         .onAppear {
             if !initialized {
@@ -79,7 +93,7 @@ struct NativeUISelectRenderer: View {
             }
         }
         .modifier(A11yLabelModifier(label: a11yLabel))
-        .modifier(A11yHintModifier(hint: a11yHint))
+        .modifier(A11yHintModifier(hint: effectiveA11yHint))
     }
 }
 

--- a/src/Elements/Checkbox.php
+++ b/src/Elements/Checkbox.php
@@ -40,6 +40,13 @@ class Checkbox extends Element
             $this->disabled();
         }
 
+        if (isset($attrs['supporting'])) {
+            $this->supporting($attrs['supporting']);
+        }
+        if (! empty($attrs['error']) || ! empty($attrs['isError']) || ! empty($attrs['is-error'])) {
+            $this->error();
+        }
+
         $this->applyA11yAttributes($attrs);
 
         if (isset($attrs['sync-mode']) || isset($attrs['syncMode'])) {
@@ -117,4 +124,20 @@ class Checkbox extends Element
 
         return $layout;
     }
+    /** Supporting/helper text under the control (error-colored when error()). */
+    public function supporting(string $text): static
+    {
+        $this->checkboxProps['supporting'] = $text;
+
+        return $this;
+    }
+
+    /** Flag the control as invalid — destructive tint + supporting text color. */
+    public function error(bool $on = true): static
+    {
+        $this->checkboxProps['is_error'] = $on;
+
+        return $this;
+    }
+
 }

--- a/src/Elements/Checkbox.php
+++ b/src/Elements/Checkbox.php
@@ -124,6 +124,7 @@ class Checkbox extends Element
 
         return $layout;
     }
+
     /** Supporting/helper text under the control (error-colored when error()). */
     public function supporting(string $text): static
     {
@@ -139,5 +140,4 @@ class Checkbox extends Element
 
         return $this;
     }
-
 }

--- a/src/Elements/DatePicker.php
+++ b/src/Elements/DatePicker.php
@@ -152,6 +152,13 @@ class DatePicker extends Element
             $this->syncMode((string) ($attrs['sync-mode'] ?? $attrs['syncMode']));
         }
 
+        if (isset($attrs['supporting'])) {
+            $this->supporting($attrs['supporting']);
+        }
+        if (! empty($attrs['error']) || ! empty($attrs['isError']) || ! empty($attrs['is-error'])) {
+            $this->error();
+        }
+
         $this->applyA11yAttributes($attrs);
     }
 
@@ -462,4 +469,20 @@ class DatePicker extends Element
 
         return $layout;
     }
+    /** Supporting/helper text under the control (error-colored when error()). */
+    public function supporting(string $text): static
+    {
+        $this->pickerProps['supporting'] = $text;
+
+        return $this;
+    }
+
+    /** Flag the control as invalid — destructive tint + supporting text color. */
+    public function error(bool $on = true): static
+    {
+        $this->pickerProps['is_error'] = $on;
+
+        return $this;
+    }
+
 }

--- a/src/Elements/DatePicker.php
+++ b/src/Elements/DatePicker.php
@@ -469,6 +469,7 @@ class DatePicker extends Element
 
         return $layout;
     }
+
     /** Supporting/helper text under the control (error-colored when error()). */
     public function supporting(string $text): static
     {
@@ -484,5 +485,4 @@ class DatePicker extends Element
 
         return $this;
     }
-
 }

--- a/src/Elements/RadioGroup.php
+++ b/src/Elements/RadioGroup.php
@@ -42,6 +42,13 @@ class RadioGroup extends Element
             $this->disabled();
         }
 
+        if (isset($attrs['supporting'])) {
+            $this->supporting($attrs['supporting']);
+        }
+        if (! empty($attrs['error']) || ! empty($attrs['isError']) || ! empty($attrs['is-error'])) {
+            $this->error();
+        }
+
         $this->applyA11yAttributes($attrs);
 
         if (isset($attrs['sync-mode']) || isset($attrs['syncMode'])) {
@@ -101,4 +108,20 @@ class RadioGroup extends Element
     {
         return [];
     }
+    /** Supporting/helper text under the control (error-colored when error()). */
+    public function supporting(string $text): static
+    {
+        $this->radioGroupProps['supporting'] = $text;
+
+        return $this;
+    }
+
+    /** Flag the control as invalid — destructive tint + supporting text color. */
+    public function error(bool $on = true): static
+    {
+        $this->radioGroupProps['is_error'] = $on;
+
+        return $this;
+    }
+
 }

--- a/src/Elements/RadioGroup.php
+++ b/src/Elements/RadioGroup.php
@@ -108,6 +108,7 @@ class RadioGroup extends Element
     {
         return [];
     }
+
     /** Supporting/helper text under the control (error-colored when error()). */
     public function supporting(string $text): static
     {
@@ -123,5 +124,4 @@ class RadioGroup extends Element
 
         return $this;
     }
-
 }

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -135,6 +135,7 @@ class Select extends Element
 
         return $layout;
     }
+
     /** Supporting/helper text under the control (error-colored when error()). */
     public function supporting(string $text): static
     {
@@ -150,5 +151,4 @@ class Select extends Element
 
         return $this;
     }
-
 }

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -46,6 +46,13 @@ class Select extends Element
             $this->disabled();
         }
 
+        if (isset($attrs['supporting'])) {
+            $this->supporting($attrs['supporting']);
+        }
+        if (! empty($attrs['error']) || ! empty($attrs['isError']) || ! empty($attrs['is-error'])) {
+            $this->error();
+        }
+
         $this->applyA11yAttributes($attrs);
 
         if (isset($attrs['sync-mode']) || isset($attrs['syncMode'])) {
@@ -128,4 +135,20 @@ class Select extends Element
 
         return $layout;
     }
+    /** Supporting/helper text under the control (error-colored when error()). */
+    public function supporting(string $text): static
+    {
+        $this->selectProps['supporting'] = $text;
+
+        return $this;
+    }
+
+    /** Flag the control as invalid — destructive tint + supporting text color. */
+    public function error(bool $on = true): static
+    {
+        $this->selectProps['is_error'] = $on;
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
## Summary

The validation audit (core mobile-air#301 context) found `is_error`/`supporting` rendered ONLY on text inputs — every other form element silently swallowed validation errors on all targets. This adds the display to the four commonly-validated elements on every layer:

- **iOS (SwiftUI)**: destructive border/tint on error, supporting `Text` below the control, error message announced via the a11y hint channel unless an explicit hint is set — same conventions as the shipping text inputs.
- **Android (Compose)**: first-class `isError`/`supportingText` on the `OutlinedTextField`-based controls (Select, DatePicker trigger), destructive checkbox tint + supporting `Text`, RadioGroup label tint + supporting `Text`; hint-channel announcement likewise.
- **PHP elements**: `supporting` and `error`/`isError`/`is-error` attributes + `supporting()`/`error()` builder methods mirroring `BaseTextInput`.

Deliberately NOT added: Slider, Toggle, Chip, ButtonGroup — rarely validated; the same pattern applies when needed.

Blessed usage (explicit-only display, per the core validation semantics):

```blade
<native:select native:model="color" :options="$colors"
    :error="$errors->has('color')"
    :supporting="$errors->first('color')" />
```

## Verification

- Web emitters (mobile-web#1 counterpart): 6-check render harness + an 18-check end-to-end settings-screen harness in xclone, all green.
- **Android: compile-verified in a real app build** (`:app:compileDebugKotlin` clean with these renderers compiled in) and exercised on-device via xclone's `/settings` demo screen.
- **iOS: the Swift is a pattern-copy of the shipping text-input renderers but has NOT been through an Xcode build yet** — please build once before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)