### PR TITLE
SVG support in `native:image`

### DIFF
--- a/nativephp.json
+++ b/nativephp.json
@@ -499,6 +499,7 @@
             "implementation": [
                 "io.coil-kt.coil3:coil-compose:3.1.0",
                 "io.coil-kt.coil3:coil-network-okhttp:3.1.0",
+                "io.coil-kt.coil3:coil-svg:3.1.0",
                 "androidx.compose.material:material-icons-core",
                 "androidx.compose.material:material-icons-extended"
             ]

--- a/nativephp.json
+++ b/nativephp.json
@@ -509,7 +509,15 @@
         "min_version": 18.2,
         "init_function": "registerNativeUIChrome",
         "dependencies": {
-            "swift_packages": [],
+            "swift_packages": [
+                {
+                    "url": "https://github.com/swhitty/SwiftDraw",
+                    "version": "0.29.0",
+                    "products": [
+                        "SwiftDraw"
+                    ]
+                }
+            ],
             "pods": []
         }
     },

--- a/resources/ios/NativeUISimpleRenderers.swift
+++ b/resources/ios/NativeUISimpleRenderers.swift
@@ -194,7 +194,12 @@ struct NativeUIImageRenderer: View {
 
     @ViewBuilder
     private func tinted(_ image: Image, contentMode: ContentMode, tintArgb: Int, cornerRadius: CGFloat) -> some View {
-        image
+        // `foregroundStyle` only recolours a template image. A UIImage decoded
+        // from a file or a URL is `.original`, so the tint had nothing to act
+        // on and was dropped silently.
+        let source = tintArgb != 0 ? image.renderingMode(.template) : image
+
+        source
             .resizable()
             .aspectRatio(contentMode: contentMode)
             .modifier(ImageTintModifier(tintArgb: tintArgb))

--- a/resources/ios/NativeUISimpleRenderers.swift
+++ b/resources/ios/NativeUISimpleRenderers.swift
@@ -188,45 +188,11 @@ struct NativeUIImageRenderer: View {
 
     @ViewBuilder
     private func tinted(_ image: Image, contentMode: ContentMode, tintArgb: Int, cornerRadius: CGFloat) -> some View {
-        let img = image
+        image
             .resizable()
             .aspectRatio(contentMode: contentMode)
-        let styled = Group {
-            if tintArgb != 0 {
-                img.foregroundStyle(Color(argb: tintArgb))
-            } else {
-                img
-            }
-        }
-
-        // `.fill` (cover/fill) spans the whole frame, so the frame-level
-        // rounded clip from NodeStyleModifier already rounds the visible
-        // pixels. `.fit` (contain/scale-down/none) letterboxes the image
-        // inside the frame, leaving the frame's rounded corners out in the
-        // transparent margin — so round the fitted image itself. Mirrors
-        // ClipRadiusModifier (RoundedRectangle; rounded-full → 9999 clamps
-        // to a capsule).
-        if contentMode == .fit && cornerRadius > 0 {
-            styled.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-        } else {
-            styled
-        }
-    }
-
-    /// HTML `<img alt>` semantics for VoiceOver: an `alt` prop makes the
-    /// image a labeled image element; no `alt` marks it decorative and hides
-    /// it from the accessibility tree entirely.
-    private struct ImageAltModifier: ViewModifier {
-        let alt: String
-        func body(content: Content) -> some View {
-            if alt.isEmpty {
-                content.accessibilityHidden(true)
-            } else {
-                content
-                    .accessibilityLabel(alt)
-                    .accessibilityAddTraits(.isImage)
-            }
-        }
+            .modifier(ImageTintModifier(tintArgb: tintArgb))
+            .modifier(FittedCornerModifier(contentMode: contentMode, cornerRadius: cornerRadius))
     }
 
     /// Resolves `src` to a local filesystem path when it points at an
@@ -241,12 +207,58 @@ struct NativeUIImageRenderer: View {
         }
         return nil
     }
+}
 
-    private func resolveContentMode(_ fit: Int) -> ContentMode {
-        switch fit {
-        case 2: return .fill
-        case 3: return .fill
-        default: return .fit
+/// Maps the `fit` ordinal to a SwiftUI content mode.
+private func resolveContentMode(_ fit: Int) -> ContentMode {
+    switch fit {
+    case 2: return .fill
+    case 3: return .fill
+    default: return .fit
+    }
+}
+
+/// HTML `<img alt>` semantics for VoiceOver: an `alt` prop makes the image a
+/// labeled image element; no `alt` marks it decorative and hides it from the
+/// accessibility tree entirely.
+private struct ImageAltModifier: ViewModifier {
+    let alt: String
+    func body(content: Content) -> some View {
+        if alt.isEmpty {
+            content.accessibilityHidden(true)
+        } else {
+            content
+                .accessibilityLabel(alt)
+                .accessibilityAddTraits(.isImage)
+        }
+    }
+}
+
+private struct ImageTintModifier: ViewModifier {
+    let tintArgb: Int
+    func body(content: Content) -> some View {
+        if tintArgb != 0 {
+            content.foregroundStyle(Color(argb: tintArgb))
+        } else {
+            content
+        }
+    }
+}
+
+/// `.fill` (cover/fill) spans the whole frame, so the frame-level rounded clip
+/// from NodeStyleModifier already rounds the visible pixels. `.fit`
+/// (contain/scale-down/none) letterboxes the content inside the frame, leaving
+/// the frame's rounded corners out in the transparent margin — so round the
+/// fitted content itself. Mirrors ClipRadiusModifier (RoundedRectangle;
+/// rounded-full → 9999 clamps to a capsule).
+private struct FittedCornerModifier: ViewModifier {
+    let contentMode: ContentMode
+    let cornerRadius: CGFloat
+    func body(content: Content) -> some View {
+        if contentMode == .fit && cornerRadius > 0 {
+            content.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        } else {
+            content
         }
     }
 }

--- a/resources/ios/NativeUISimpleRenderers.swift
+++ b/resources/ios/NativeUISimpleRenderers.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftDraw
 import UIKit
 
 struct NativeUIPressableRenderer: View {
@@ -157,7 +158,12 @@ struct NativeUIImageRenderer: View {
     private func imageContent(src: String, contentMode: ContentMode, tintArgb: Int, cornerRadius: CGFloat) -> some View {
         if src.isEmpty {
             Color.clear
-        } else if let path = Self.localFilePath(for: src) {
+        } else if isSVGSource(src) {
+            // Vectors never become bitmaps: SVGView draws through a Canvas and
+            // stays sharp at any size, so an 8pt viewBox blown up to 96pt is
+            // exact rather than an upscaled raster.
+            NativeUISVGContent(src: src, contentMode: contentMode, tintArgb: tintArgb, cornerRadius: cornerRadius)
+        } else if let path = localFilePath(for: src) {
             // Local device file — camera capture, gallery selection, etc.
             // `AsyncImage`/`URLSession` can't load `file://` or bare
             // filesystem paths, so decode directly with UIImage. Handles
@@ -195,17 +201,129 @@ struct NativeUIImageRenderer: View {
             .modifier(FittedCornerModifier(contentMode: contentMode, cornerRadius: cornerRadius))
     }
 
-    /// Resolves `src` to a local filesystem path when it points at an
-    /// on-device file (`file://…` URL or an absolute `/…` path), or nil
-    /// when it's a remote URL that should go through AsyncImage.
-    private static func localFilePath(for src: String) -> String? {
-        if src.hasPrefix("file://") {
-            return URL(string: src)?.path ?? String(src.dropFirst("file://".count))
+}
+
+/// Resolves `src` to a local filesystem path when it points at an on-device
+/// file (`file://…` URL or an absolute `/…` path), or nil when it's a remote
+/// URL that should go through AsyncImage.
+private func localFilePath(for src: String) -> String? {
+    if src.hasPrefix("file://") {
+        return URL(string: src)?.path ?? String(src.dropFirst("file://".count))
+    }
+    if src.hasPrefix("/") {
+        return src
+    }
+    return nil
+}
+
+/// Classifies `src` as SVG content, or nil when it isn't SVG. Inline markup
+/// and data URIs are recognised by their prefix; files and remote URLs by
+/// extension, since neither can be sniffed without reading them first.
+/// Detection and loading share this one classification, so every source the
+/// renderer routes to the SVG branch is one the loader knows how to fetch.
+private enum SVGSource {
+    case markup(String)
+    case dataURI(String)
+    case remote(URL)
+    case localFile(String)
+    case bundled(String)
+
+    init?(_ src: String) {
+        let trimmed = src.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.hasPrefix("<svg") || trimmed.hasPrefix("<?xml") {
+            self = .markup(trimmed)
+            return
         }
-        if src.hasPrefix("/") {
-            return src
+        if trimmed.hasPrefix("data:image/svg+xml") {
+            self = .dataURI(trimmed)
+            return
         }
-        return nil
+
+        let path = URL(string: trimmed)?.path ?? trimmed
+        guard (path as NSString).pathExtension.lowercased() == "svg" else {
+            return nil
+        }
+
+        if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://"), let url = URL(string: trimmed) {
+            self = .remote(url)
+            return
+        }
+        if let filePath = localFilePath(for: trimmed) {
+            self = .localFile(filePath)
+            return
+        }
+        self = .bundled(trimmed)
+    }
+}
+
+private func isSVGSource(_ src: String) -> Bool {
+    SVGSource(src) != nil
+}
+
+/// Parses an SVG source off the main actor, then draws it with the same tint
+/// and corner treatment as a raster image. Parsing is a `task(id:)` rather
+/// than a computed value because a remote source has to be fetched.
+private struct NativeUISVGContent: View {
+    let src: String
+    let contentMode: ContentMode
+    let tintArgb: Int
+    let cornerRadius: CGFloat
+
+    @State private var svg: SVG?
+
+    var body: some View {
+        Group {
+            if let svg {
+                SVGView(svg: svg)
+                    .renderingMode(tintArgb != 0 ? .template : .original)
+                    .resizable()
+                    .aspectRatio(contentMode: contentMode)
+            } else {
+                // Covers "still loading" and "failed to parse" alike, matching
+                // the raster branch's empty result for an undecodable source.
+                Color.clear
+            }
+        }
+        .modifier(ImageTintModifier(tintArgb: tintArgb))
+        .modifier(FittedCornerModifier(contentMode: contentMode, cornerRadius: cornerRadius))
+        .task(id: src) {
+            svg = await Self.parse(src)
+        }
+    }
+
+    private static func parse(_ src: String) async -> SVG? {
+        guard let source = SVGSource(src) else { return nil }
+
+        switch source {
+        case .markup(let xml):
+            return SVG(xml: xml)
+        case .dataURI(let uri):
+            guard let data = decodeDataURI(uri) else { return nil }
+            return SVG(data: data)
+        case .remote(let url):
+            guard let (data, _) = try? await URLSession.shared.data(from: url) else { return nil }
+            return SVG(data: data)
+        case .localFile(let path):
+            return SVG(fileURL: URL(fileURLWithPath: path))
+        case .bundled(let name):
+            return SVG(named: name, in: .main)
+        }
+    }
+
+    /// RFC 2397: the payload is base64 when the media type carries the marker,
+    /// and percent-encoded text otherwise.
+    private static func decodeDataURI(_ src: String) -> Data? {
+        let parts = src.split(separator: ",", maxSplits: 1)
+        guard parts.count == 2 else { return nil }
+
+        let payload = String(parts[1])
+
+        if parts[0].contains("base64") {
+            return Data(base64Encoded: payload)
+        }
+
+        return payload.removingPercentEncoding?.data(using: .utf8)
     }
 }
 


### PR DESCRIPTION
## Summary

`<native:image>` now draws SVG as well as raster. No new element, no new attribute — point `src` at SVG content and it renders as a vector.

### Why

SVG is the format the assets an app cares most about already ship in.

- **Logos and brand material.** A brand kit arrives as SVG. Without vector support each mark has to be pre-rendered to PNG at every density it might appear at, re-exported whenever the brand changes, and it still softens wherever a layout sizes it larger than planned. As a vector one file covers every size, and `tintColor` recolours it per theme instead of shipping a light and a dark copy.
- **Barcodes and QR codes.** These often are generated as SVG — including by `endroid/qr-code`, which core already depends on — and they are read by a camera, so edge fidelity is the whole point. A bitmap rasterized at the wrong size blurs the quiet zone and the finder patterns, and scanning gets slower or fails outright. Drawn as a vector the code is exact at whatever size the screen gives it.
- **Icon sets and illustrations** distributed as SVG stop needing a raster export step to be usable.

Without this the workarounds are pre-rendering PNGs per density, or dropping to a web view to get an `<img>` — which forfeits native layout and gestures for the sake of one graphic.

Vectors are never rasterized. Android decodes through `coil-svg`; iOS draws with SwiftDraw's `SVGView`, a Canvas-backed view. Both stay sharp at any display size, so a small `viewBox` blown up is exact rather than an upscaled bitmap. `fit`, `tintColor`, corner radius and `alt` behave exactly as they do for raster, because the SVG path reuses the same view modifiers.

Screenshot of visual difference between SVG and small PNG icon:

<img width="480" alt="Simulator Screenshot - iPhone 17 - 2026-08-10 at 11 04 12" src="https://github.com/user-attachments/assets/7b104d3d-b1d8-4944-a192-194a9283cfba" />


## Commits

| Commit | What |
|---|---|
| `6662a2e` | Android: add `coil-svg` to the plugin manifest |
| `8d42c50` | iOS: extract shared view modifiers to file scope (no behaviour change) |
| `1a3d257` | iOS: the SVG branch |
| `90d2240` | iOS: apply `tint_color` to raster images |

**Android needs no renderer change at all.** `coil-svg` self-registers through Coil's `ServiceLoader` (`SvgDecoderServiceLoaderTarget`, enabled by default via `Extras.Key(default = true)` and consumed at `RealImageLoader.kt:269`), so the whole Android side is one line in `nativephp.json` and `ImageRenderer.kt` is untouched.

### On the last commit

`90d2240` is not an SVG change, and it is here because it is the same one-line fix as the SVG path's.

`ImageTintModifier` applies `foregroundStyle`, which only recolours a *template* image. The SVG path opts in with `SVGView.renderingMode(.template)` when a tint is set, so `tintColor` works on vectors. The raster path never opted in — a `UIImage` decoded from a file or a URL is `.original`, so the shared tint modifier had nothing to act on and the tint was dropped silently. Android applies `ColorFilter.tint` regardless, so the same markup tinted on one platform and not the other.

Shipping the SVG opt-in without the raster one would mean leaving two callers of the same modifier deliberately inconsistent. Untinted images are unaffected. If you would rather see it as its own PR, say so and I will lift it out.

## Recognised sources

| `src` | iOS | Android |
|---|---|---|
| `.svg` path, or `file://…/x.svg` | yes | yes |
| `https://…/x.svg` | yes | yes |
| `data:image/svg+xml;base64,…` | yes | yes |
| `data:image/svg+xml,%3Csvg…` (percent-encoded) | yes | **no** |
| inline `<svg …>` markup passed as `src` | yes | **no** |

Android selects by content: Coil sniffs the bytes it fetched, so an SVG served without a `.svg` extension renders anyway. iOS selects by prefix for markup and data URIs, and by extension for files and URLs, since neither can be inspected before it is read. On iOS one `SVGSource` classification drives both the detection and the loading, so every source routed to the SVG branch is one the loader knows how to fetch.

Both Android gaps are Coil's. Its `DataUriFetcher` requires the `;base64,` marker and returns nothing without it, and a bare markup string is not a source it fetches. Base64-encoded SVG data URIs work on both platforms.

## Platform notes

- **`<text>` renders on both.** Font selection is the host's, so a family the device lacks is substituted rather than dropped. Convert text to outlines when the exact face matters.
- **`object-none` is honoured on Android and not on iOS.** Android maps it to `ContentScale.None`; iOS falls through `resolveContentMode`'s default and letterboxes, because SwiftUI's `ContentMode` has no member for "do not scale". This is existing iOS behaviour for raster images and the SVG path matches it rather than diverging. Fixing it is a separate PR — the expression is to omit `.resizable()`, and the alignment and density questions that come with it have nothing to do with SVG.
- **Fitted content aligns differently.** `object-contain` letterboxes to the leading edge on iOS and centres on Android. This predates SVG, applies to raster identically, and comes from the shared layout rather than the image renderer — so it is out of scope here and worth its own issue.
- **An undecodable source renders as empty space** on both platforms, the same as a missing file, and never throws.

## Dependencies

- Android: `io.coil-kt.coil3:coil-svg:3.1.0` in `android.dependencies.implementation`
- iOS: `swhitty/SwiftDraw` `0.29.0` in `ios.dependencies.swift_packages` — the first use of that manifest slot in this plugin

Both link unconditionally, so apps that never render an SVG still carry them. Worth a maintainer's opinion on whether either should be opt-in; there is no mechanism for optional plugin dependencies today.

## Verification

Device-tested on both platforms against one screen that renders every SVG case beside an identical raster control, so a difference between columns is a pipeline bug and a difference between platforms is a decoder bug.

Covered: fit modes, tint, corner radius, gradient fills, `clip-path` into `defs`,
a 7.3:1 aspect ratio, missing `viewBox`, an 8px `viewBox` upscaled to 96pt,
`<text>`, local files, remote URLs, all three data-URI forms, malformed SVG, and
missing files.

Both renderers behave identically to their raster control in every case except the platform notes above.

The screen is not part of this PR, but it is attached as a zip so it can be dropped into any NativePHP app to reproduce the results — component, Blade view, fixtures in their directory structure, and an INSTALL.md with the route line and
the expected per-platform differences.

[svg-test-screen.zip](https://github.com/user-attachments/files/30892284/svg-test-screen.zip)
