### PR TITLE
[Masterclass] Derive autocapitalization from the keyboard type, and add an autocapitalize override

### DIFF
--- a/resources/android/TextInputShared.kt
+++ b/resources/android/TextInputShared.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.TextFieldValue
@@ -50,6 +51,7 @@ internal data class TextInputProps(
     val minLines: Int,
     val maxLength: Int,
     val keyboard: KeyboardType,
+    val capitalization: KeyboardCapitalization?,
     val disabled: Boolean,
     val readOnly: Boolean,
     val isError: Boolean,
@@ -113,6 +115,7 @@ internal fun parseTextInputProps(node: NativeUINode): TextInputProps {
         minLines     = p.getInt("min_lines").let { if (it > 0) it else 1 },
         maxLength    = p.getInt("max_length"),
         keyboard     = resolveKeyboardType(p.getString("keyboard")),
+        capitalization = resolveCapitalization(p.getString("autocapitalize"), p.getString("keyboard")),
         disabled     = p.getBool("disabled"),
         readOnly     = p.getBool("read_only"),
         isError      = p.getBool("is_error"),
@@ -167,8 +170,42 @@ internal fun resolveKeyboardType(kind: String): KeyboardType = when (kind.lowerc
     else             -> KeyboardType.Text
 }
 
+/**
+ * Capitalization from the explicit `autocapitalize` prop when the author set
+ * one, otherwise derived from the keyboard type. Null means "leave Compose's
+ * own default alone".
+ *
+ * Compose already defaults to no capitalization, so Android never had the iOS
+ * bug (mobile-air #304) — it got the right answer by accident rather than on
+ * purpose, and `autocapitalize` had no way to take effect at all.
+ *
+ * The plain-text case deliberately returns NULL rather than `Sentences`.
+ * Sentences is what iOS does and would make the platforms agree, but it would
+ * also silently start capitalizing every unclassified text field in every
+ * existing Android app. That default is a separate decision; this change only
+ * makes the prop work and pins the cases the keyboard type already implies.
+ *
+ * Unknown values fall through to the derived behaviour rather than erroring,
+ * matching `resolveKeyboardType`.
+ */
+internal fun resolveCapitalization(explicit: String, keyboard: String): KeyboardCapitalization? =
+    when (explicit.lowercase()) {
+        "none"       -> KeyboardCapitalization.None
+        "sentences"  -> KeyboardCapitalization.Sentences
+        "words"      -> KeyboardCapitalization.Words
+        "characters" -> KeyboardCapitalization.Characters
+        else -> when (keyboard.lowercase()) {
+            // Case-sensitive or non-alphabetic content — never capitalize.
+            "email", "url", "number", "decimal", "phone",
+            "numberpassword", "password" -> KeyboardCapitalization.None
+            else -> null
+        }
+    }
+
 internal fun keyboardOptionsFor(props: TextInputProps): KeyboardOptions =
-    KeyboardOptions(keyboardType = props.keyboard)
+    props.capitalization
+        ?.let { KeyboardOptions(keyboardType = props.keyboard, capitalization = it) }
+        ?: KeyboardOptions(keyboardType = props.keyboard)
 
 /**
  * Outbound dispatch state machine. Call [onTextChanged] whenever local text

--- a/resources/ios/NativeUITextInputCore.swift
+++ b/resources/ios/NativeUITextInputCore.swift
@@ -59,7 +59,16 @@ struct NativeUITextInputCore: View {
         let minLines      = p.getInt("min_lines")
         let disabled      = p.getBool("disabled")
         let readOnly      = p.getBool("read_only")
-        let keyboard      = resolveKeyboardType(p.getString("keyboard"))
+        let keyboardKind  = p.getString("keyboard")
+        let keyboard      = resolveKeyboardType(keyboardKind)
+        // Capitalization and autocorrect are derived from the keyboard type
+        // unless the author overrode them — declaring a field `email` should
+        // carry its typing behaviour, not just its key layout.
+        let capitalization = resolveAutocapitalization(
+            explicit: p.getString("autocapitalize"),
+            keyboard: keyboardKind
+        )
+        let autocorrect   = allowsAutocorrection(keyboard: keyboardKind)
         let onChangeCb    = p.getCallbackId("on_change")
         let onSubmitCb    = p.getCallbackId("on_submit")
         let syncMode      = p.getString("sync_mode", default: "live")
@@ -140,6 +149,8 @@ struct NativeUITextInputCore: View {
         .lineSpacing(lineSpacing)
         .tint(tintColor)
         .keyboardType(keyboard)
+        .textInputAutocapitalization(capitalization)
+        .autocorrectionDisabled(!autocorrect)
         .disabled(disabled || readOnly)
         .submitLabel(onSubmitCb != 0 ? .done : .return)
         .onAppear {
@@ -422,5 +433,51 @@ private func resolveKeyboardType(_ kind: String) -> UIKeyboardType {
     case "decimal":        return .decimalPad
     case "numberpassword": return .numberPad
     default:               return .default
+    }
+}
+
+/// Capitalization for the field, from the explicit `autocapitalize` prop when
+/// the author set one, otherwise derived from the keyboard type.
+///
+/// SwiftUI defaults an untouched TextField to `.sentences`, which is why an
+/// email field capitalized its first letter even though `.emailAddress` was
+/// applied: `keyboardType` sets the key layout and nothing else. Every keyboard
+/// kind whose content is case-sensitive or non-alphabetic therefore has to opt
+/// out explicitly.
+///
+/// Unknown `autocapitalize` values fall through to the derived behaviour rather
+/// than erroring — same policy as `resolveKeyboardType`.
+private func resolveAutocapitalization(explicit: String, keyboard: String) -> TextInputAutocapitalization {
+    switch explicit.lowercased() {
+    case "none":       return .never
+    case "sentences":  return .sentences
+    case "words":      return .words
+    case "characters": return .characters
+    default:           break
+    }
+
+    switch keyboard.lowercased() {
+    // Case-sensitive content — capitalizing the first character is always
+    // wrong here (an email's local part, a URL's path).
+    case "email", "url":
+        return .never
+    // Numeric keypads have no shift key, so capitalization is moot; `.never`
+    // just keeps the state honest if the user swaps to a hardware keyboard.
+    case "number", "decimal", "phone", "numberpassword", "password":
+        return .never
+    default:
+        return .sentences
+    }
+}
+
+/// Whether autocorrect should run. Same reasoning as capitalization: iOS will
+/// happily "correct" an email local part or a URL slug into a dictionary word,
+/// and the field type is enough to know that's unwanted.
+private func allowsAutocorrection(keyboard: String) -> Bool {
+    switch keyboard.lowercased() {
+    case "email", "url", "number", "decimal", "phone", "numberpassword", "password":
+        return false
+    default:
+        return true
     }
 }

--- a/src/Elements/BaseTextInput.php
+++ b/src/Elements/BaseTextInput.php
@@ -19,7 +19,7 @@ use Native\Mobile\Icon\IosSymbol;
  * Allowed per-instance:
  *   - `value`, `placeholder`, `label`, `supporting`  (content)
  *   - `disabled`, `readOnly`, `error`, `loading`     (state)
- *   - `keyboard`, `secure`, `maxLength`, `multiline`, `maxLines`, `minLines` (behavior)
+ *   - `keyboard`, `autocapitalize`, `secure`, `maxLength`, `multiline`, `maxLines`, `minLines` (behavior)
  *   - `prefix`, `suffix`, `leading-icon`, `trailing-icon` (decorations)
  *   - `size`                                          (sm | md | lg)
  *   - `a11y-label`, `a11y-hint`                       (accessibility)
@@ -85,6 +85,9 @@ abstract class BaseTextInput extends Element
         // Behavior
         if (isset($attrs['keyboard'])) {
             $this->keyboard($attrs['keyboard']);
+        }
+        if (isset($attrs['autocapitalize']) || isset($attrs['autoCapitalize'])) {
+            $this->autocapitalize((string) ($attrs['autocapitalize'] ?? $attrs['autoCapitalize']));
         }
         if (! empty($attrs['secure'])) {
             $this->secure();
@@ -250,6 +253,26 @@ abstract class BaseTextInput extends Element
     public function keyboard(string|int $type): static
     {
         $this->inputProps['keyboard'] = $type;
+
+        return $this;
+    }
+
+    /**
+     * Autocapitalization — "none" | "sentences" | "words" | "characters".
+     * Mirrors HTML's `autocapitalize` vocabulary.
+     *
+     * Leave it unset and the field derives capitalization from its `keyboard`
+     * type, which is what you want almost always: an `email` or `url` field
+     * capitalizes nothing, a plain text field capitalizes sentences. This
+     * setter exists for the cases the keyboard type can't imply — a name field
+     * wanting `words`, or a reference-code field wanting `characters`.
+     *
+     * Unknown values are ignored natively and fall back to the derived
+     * behaviour rather than erroring.
+     */
+    public function autocapitalize(string $mode): static
+    {
+        $this->inputProps['autocapitalize'] = strtolower(trim($mode));
 
         return $this;
     }

--- a/tests/CollectorElementsTest.php
+++ b/tests/CollectorElementsTest.php
@@ -484,3 +484,32 @@ it('parses string booleans on the new sheet props via filter_var', function () {
     expect($tree['props']['permanent'])->toBeFalse();
     expect($tree['props']['background_interaction'])->toBeFalse();
 });
+
+// ── autocapitalize (mobile-air #304) ─────────────────────────────────────────
+
+it('serializes autocapitalize via the fluent API', function () {
+    $props = OutlinedTextInput::make()
+        ->autocapitalize('Words')
+        ->toArray(new CallbackRegistry)['props'];
+
+    // Normalized to lower case so the native resolvers can match on one form.
+    expect($props['autocapitalize'])->toBe('words');
+});
+
+it('serializes autocapitalize from both attribute spellings', function (string $attr) {
+    $el = OutlinedTextInput::make();
+    $el->applyAttributes([$attr => 'characters']);
+
+    expect($el->toArray(new CallbackRegistry)['props']['autocapitalize'])->toBe('characters');
+})->with(['autocapitalize', 'autoCapitalize']);
+
+it('omits autocapitalize entirely when the author did not set one', function () {
+    // Absent means "derive from the keyboard type" on both platforms — the
+    // native resolvers must not see an empty string as an explicit choice.
+    $props = OutlinedTextInput::make()
+        ->keyboard('email')
+        ->toArray(new CallbackRegistry)['props'];
+
+    expect($props)->not->toHaveKey('autocapitalize')
+        ->and($props['keyboard'])->toBe('email');
+});


### PR DESCRIPTION
Fixes NativePHP/mobile-air#304. cc @shrutibalasawebdev

> Lives here rather than in mobile-air: the text input renderer is a plugin component. The issue is filed on mobile-air, so the cross-repo `Fixes` reference won't auto-close it — worth closing by hand on merge.

Demo: `/masterclass/autocapitalize` in the super-native demo app, under the **Masterclass Fixes** group.

---

## Cause

`NativeUITextInputCore` applied `.keyboardType(keyboard)` and nothing else.

On iOS, `keyboardType` sets the **key layout only** — it says nothing about capitalization, and an untouched SwiftUI `TextField` defaults to `.sentences`.

That's exactly why @shrutibalasawebdev's report was so precise: the email keyboard *did* appear, so `keyboard="email"` was demonstrably being applied — it just doesn't carry capitalization with it. Nothing was broken here; the behaviour was simply never wired.

## Fix — the two halves the issue asked for

**1. The field type carries its typing behaviour.**

Every keyboard kind whose content is case-sensitive or non-alphabetic — `email`, `url`, `number`, `decimal`, `phone`, `password` — now resolves to `.never`.

Autocorrect is disabled for the same set. A slight extension of the report, but it's the identical bug wearing a different hat: iOS will otherwise happily "correct" an email local part into a dictionary word, and the issue's own framing was that *"declaring the field type should carry the capitalization behaviour with it, the same way it carries the keyboard layout."*

**2. A new `autocapitalize` attribute** — the issue noted *"there does not appear to be a separate attribute to turn autocapitalization off."*

`none` | `sentences` | `words` | `characters` — HTML's vocabulary. It covers what a keyboard type can't imply: a name field wanting `words`, a booking reference wanting `characters`. It overrides the derived value, and unknown values fall back to the derived behaviour rather than erroring (same policy as `resolveKeyboardType`).

Available as an attribute (`autocapitalize` / `autoCapitalize`) and as a fluent setter.

## Android

Android never had the bug — Compose's `KeyboardOptions` defaults to no capitalization — but it got the right answer **by accident**, and `autocapitalize` had nowhere to land at all. It now resolves the same prop through the same rules, so the platforms agree by construction rather than coincidence.

## One deliberate asymmetry

For a **plain text field with nothing specified**, iOS capitalizes sentences and Android does not.

`resolveCapitalization` returns **null** for that case rather than `Sentences`, leaving Compose's default alone. Matching iOS would unify the platforms, but it would also silently start capitalizing every unclassified text field in every existing Android app — that default deserves its own decision, not a side effect of this fix.

So Android behaviour changes **only** when the author sets `autocapitalize`, or uses a keyboard type that already implied `None`. It's the one ⚠️ section in the demo.

## Testing

- Full suite green: **217 passed**, Pint clean
- 4 new tests, including one asserting the prop is **omitted entirely** when unset — an empty string must not read as an explicit choice, or the derivation in both native resolvers is bypassed
- Covers both attribute spellings and the lower-casing normalisation

⚠️ **The Swift and Kotlin changes are compile-unverified** — no iOS or Android build has been run against this yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
