### PR TITLE
Silence the deprecated databaseEnabled warning in the webview lockdown

### DIFF
--- a/resources/android/WebviewRenderer.kt
+++ b/resources/android/WebviewRenderer.kt
@@ -273,6 +273,13 @@ private fun applyLockdownSettings(
     settings.setSupportMultipleWindows(false)
     settings.mediaPlaybackRequiresUserGesture = true
     settings.setGeolocationEnabled(false)
+    // Deprecated in API 33 — the Web SQL Database API it gates was removed from
+    // WebView entirely. Suppressed rather than deleted: `minSdk` is 26, and on
+    // an older device carrying an older WebView the setting still does
+    // something, so dropping it would quietly weaken the lockdown on exactly
+    // the devices that need it most. Same reasoning as the two suppressions
+    // above.
+    @Suppress("DEPRECATION")
     settings.databaseEnabled = false
     settings.cacheMode = WebSettings.LOAD_NO_CACHE
 }


### PR DESCRIPTION
`WebSettings.databaseEnabled` was deprecated in API 33 — the Web SQL Database API it gates has since been removed from WebView entirely — so it warns on every `compileDebugKotlin`:

```
w: WebviewRenderer.kt:276:14 'var databaseEnabled: Boolean' is deprecated. Deprecated in Java.
```

**Suppressed rather than deleted.** `minSdk` is 26, and on an older device carrying an older WebView the setting still does something — dropping it would quietly weaken this lockdown on exactly the devices that need it most. Deleting would also have been *almost* safe for a different reason (the platform default is already `false`), but this block deliberately asserts each setting rather than relying on defaults, and I'd rather not erode that.

`allowFileAccessFromFileURLs` and `allowUniversalAccessFromFileURLs` two lines above are suppressed for exactly the same reason, so this keeps the block internally consistent too.

Independent of #47 and #48 — different file, merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)