### PR TITLE
[Masterclass] Re-pin a bottom-anchored scroll view when the keyboard hides

### DIFF
--- a/resources/ios/NativeUIScrollViewRenderer.swift
+++ b/resources/ios/NativeUIScrollViewRenderer.swift
@@ -4,6 +4,13 @@ import UIKit
 struct NativeUIScrollViewRenderer: View {
     let node: NativeUINode
 
+    /// Whether the bottom anchor is currently on screen — i.e. whether the
+    /// list is still "stuck" to the bottom rather than scrolled up into
+    /// history. Only consulted for `scroll-anchor="bottom"`, and only to
+    /// decide whether a keyboard DISMISS should re-pin. Starts true because a
+    /// bottom-anchored list opens at the bottom.
+    @State private var atBottom: Bool = true
+
     var body: some View {
         let horizontal = node.props.getBool("horizontal")
         let showsIndicators = node.props.getBool("shows_indicators", default: true)
@@ -148,10 +155,16 @@ struct NativeUIScrollViewRenderer: View {
                             // reader) — this fires after the anchor has
                             // real geometry, so the pin always lands.
                             .onAppear {
+                                // The anchor being on screen IS the definition
+                                // of "still stuck to the bottom" — the keyboard
+                                // dismiss handler reads this to avoid dragging
+                                // a reader out of history.
+                                atBottom = true
                                 DispatchQueue.main.async {
                                     proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
                                 }
                             }
+                            .onDisappear { atBottom = false }
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -171,24 +184,50 @@ struct NativeUIScrollViewRenderer: View {
                     proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
                 }
             }
-            // The keyboard shrinks the scroll viewport (the screen shifts
-            // up for keyboard avoidance). Re-pin the latest message to the
-            // bottom so it stays visible just above the input row instead
-            // of hiding behind it, moving IN SYNC with the keyboard: a
-            // one-runloop `async` lets SwiftUI register the new (shrunk)
-            // safe area so `scrollTo` targets the final layout, and the
-            // scroll animates with the keyboard's own reported duration so
-            // both travel together.
+            // The keyboard resizes the scroll viewport in BOTH directions —
+            // it shrinks on the way in (the screen shifts up for keyboard
+            // avoidance) and grows back on the way out. Re-pin on each, so
+            // the latest message sits just above the input row while typing
+            // and back at the bottom edge afterwards. Handling only the show
+            // left the list stranded mid-screen with empty space beneath it
+            // once the keyboard closed.
+            //
+            // Both move IN SYNC with the keyboard: a one-runloop `async` lets
+            // SwiftUI register the new safe area so `scrollTo` targets the
+            // final layout, and the scroll animates with the keyboard's own
+            // reported duration so the two travel together.
             .onReceive(NotificationCenter.default.publisher(
                 for: UIResponder.keyboardWillShowNotification)
             ) { note in
-                guard stickBottom else { return }
-                let duration = (note.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
-                DispatchQueue.main.async {
-                    withAnimation(.easeOut(duration: duration)) {
-                        proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
-                    }
-                }
+                repinToBottom(stickBottom: stickBottom, proxy: proxy, note: note)
+            }
+            .onReceive(NotificationCenter.default.publisher(
+                for: UIResponder.keyboardWillHideNotification)
+            ) { note in
+                // Only when the list was actually sitting at the bottom.
+                // `scrollDismissesKeyboard(.interactively)` means dragging the
+                // list toward older messages is itself how you dismiss the
+                // keyboard — re-pinning unconditionally would yank the reader
+                // straight back down and undo the scroll that dismissed it.
+                guard atBottom else { return }
+                repinToBottom(stickBottom: stickBottom, proxy: proxy, note: note)
+            }
+        }
+    }
+
+    /// Scroll the bottom anchor back into view, in step with the keyboard.
+    ///
+    /// Shared by the show and hide observers so the two transitions animate
+    /// identically — the only difference between them is the caller-side
+    /// guard on `atBottom`.
+    private func repinToBottom(stickBottom: Bool, proxy: ScrollViewProxy, note: Notification) {
+        guard stickBottom else { return }
+
+        let duration = (note.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) ?? 0.25
+
+        DispatchQueue.main.async {
+            withAnimation(.easeOut(duration: duration)) {
+                proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
             }
         }
     }


### PR DESCRIPTION
Fixes NativePHP/mobile-air#316. cc @shrutibalasawebdev

Demo: `/masterclass/chat-repin` in the super-native demo app — the issue's exact layout. **Verified on device by @shanerbaner82.**

---

## Cause

`NativeUIScrollViewRenderer` observed `keyboardWillShowNotification` and nothing else.

The keyboard resizes the scroll viewport in **both** directions — it shrinks on the way in (the screen shifts up for keyboard avoidance) and grows back on the way out. Handling only the show left the list stranded mid-screen with empty space beneath it once the keyboard closed.

Which is exactly how @shrutibalasawebdev described it: *"only the first half works."* Half the bug was invisible precisely because the half that worked looked correct.

## Fix

Observe `keyboardWillHideNotification` too, sharing the show handler's animation so both transitions travel in step with the keyboard (same one-runloop defer, same keyboard-reported duration).

**The dismiss is guarded, and the guard is the point.**

`scrollDismissesKeyboard(.interactively)` means dragging the list toward older messages *is* how you dismiss the keyboard. Re-pinning unconditionally would yank the reader straight back to the bottom and undo the very scroll that dismissed it — trading this bug for a worse one.

So the hide handler only re-pins when the list was still actually sitting at the bottom, tracked by whether the existing 1pt bottom anchor is on screen (`onAppear` / `onDisappear`). The anchor being visible *is* the definition of "still stuck to the bottom", so no new machinery was needed.

The demo screen tests all three cases in order: re-pin on show, re-pin on hide, and drag-up-to-dismiss staying put.

## Android is deliberately not covered

Its `LaunchedEffect(stickBottom, contentSignal)` only fires on content change — nothing observes IME visibility, so it never re-pins for the keyboard in **either** direction. Same bug, arguably worse than iOS's.

I stopped short rather than guess. It needs `WindowInsets.isImeVisible` (an `@ExperimentalLayoutApi` opt-in not used anywhere in either repo yet), plus an equivalent at-bottom guard — and Android dismisses on drag too (`detectVerticalDragGestures { keyboardController?.hide() }`), so it needs one. The problem is that `listState.layoutInfo` read *after* an IME change already reflects the resized viewport, so every version I sketched either mis-fires on show or on drag-dismiss. That wants a device to get right.

Worth filing as its own issue.

## Testing

Full suite green: **217 passed**, Pint clean. No PHP surface changed — this is a SwiftUI observer fix, verified on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
