### PR TITLE
fix(android): apply keyboardOptions to BareTextInputRenderer

### DIFF
--- a/resources/android/BareTextInputRenderer.kt
+++ b/resources/android/BareTextInputRenderer.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -156,6 +157,7 @@ object BareTextInputRenderer {
                 }
                 innerTextField()
             },
+            keyboardOptions = keyboardOptionsFor(props),
             keyboardActions = KeyboardActions(onAny = {
                 // Flush the settled caret before the submit event fires.
                 selectionReporter.flush(value)


### PR DESCRIPTION
This PR fixes an issue on Android where the `BareTextInputRenderer` failed to display the correct IME keyboard types (e.g., `decimal`, `number`). 

The `BasicTextField` was being built without `keyboardOptions`, meaning the `keyboard` prop was parsed but never actually sent to the IME, resulting in the default text keyboard always being shown.

### Changes
* Added `import androidx.compose.foundation.text.KeyboardOptions` to `BareTextInputRenderer.kt`.
* Injected `keyboardOptions = keyboardOptionsFor(props)` into the `BasicTextField` constructor.

### Notes
* The outlined and filled renderers already implement this correctly.
* iOS is completely unaffected, as it delegates to `NativeUITextInputCore` which correctly applies `.keyboardType` natively.