### PR TITLE
Fire @press on nested text runs

### DIFF
--- a/resources/android/TextRenderer.kt
+++ b/resources/android/TextRenderer.kt
@@ -12,6 +12,9 @@ import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
@@ -23,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import com.nativephp.mobile.ui.nativerender.NativeUIBridge
 import com.nativephp.mobile.ui.nativerender.NativeUINode
 import com.nativephp.mobile.ui.nativerender.argbToComposeColor
 
@@ -142,11 +146,13 @@ private data class RunCtx(
     val italic: Boolean,
     val letterSpacingEm: Float,
     val textTransform: Int,
+    val pressCallbackId: Int,
+    val pressNodeId: Int,
 ) {
     companion object {
         // Root defaults — mirror the leaf path (16sp, normal, black, no dark
         // override, no custom font, no decoration/letter-spacing/transform).
-        val Root = RunCtx(16f, 0, 0, "", 0xFF000000.toInt(), 0, false, 0f, 0)
+        val Root = RunCtx(16f, 0, 0, "", 0xFF000000.toInt(), 0, false, 0f, 0, 0, 0)
     }
 }
 
@@ -168,6 +174,8 @@ private fun AnnotatedString.Builder.appendTextRuns(node: NativeUINode, inherited
         italic = p.getInt("font_style", if (inherited.italic) 1 else 0) == 1,
         letterSpacingEm = p.getFloat("letter_spacing", inherited.letterSpacingEm),
         textTransform = p.getInt("text_transform", inherited.textTransform),
+        pressCallbackId = if (node.onPress != 0) node.onPress else inherited.pressCallbackId,
+        pressNodeId = if (node.onPress != 0) node.id else inherited.pressNodeId,
     )
 
     val ownText = applyTransform(p.getString("text"), ctx.textTransform)
@@ -191,7 +199,26 @@ private fun AnnotatedString.Builder.appendTextRuns(node: NativeUINode, inherited
             textDecoration = resolveDecoration(p.getInt("underline"), p.getInt("line_through")),
             background = if (effectiveBg != 0) argbToComposeColor(effectiveBg) else Color.Unspecified,
         )
-        withStyle(span) { append(ownText) }
+        if (ctx.pressCallbackId != 0) {
+            // One Clickable per emitted span keeps annotation ranges flat
+            // for Compose hit-testing, even when pressable runs nest.
+            // Null link styles underline the range like a hyperlink,
+            // so the span's own decoration rides along instead.
+            val linkStyles = TextLinkStyles(
+                style = SpanStyle(textDecoration = resolveDecoration(p.getInt("underline"), p.getInt("line_through")) ?: TextDecoration.None)
+            )
+            val cb = ctx.pressCallbackId
+            val target = ctx.pressNodeId
+            withLink(
+                LinkAnnotation.Clickable(tag = "nativephp-press", styles = linkStyles, linkInteractionListener = {
+                    NativeUIBridge.sendPressEvent(cb, target)
+                })
+            ) {
+                withStyle(span) { append(ownText) }
+            }
+        } else {
+            withStyle(span) { append(ownText) }
+        }
     }
 
     node.children.filter { it.type == "text" }.forEach { child ->

--- a/resources/ios/NativeUITextRenderer.swift
+++ b/resources/ios/NativeUITextRenderer.swift
@@ -105,13 +105,15 @@ struct NativeUITextRenderer: View {
         var italic: Bool
         var letterSpacingEm: Float
         var textTransform: Int
+        var pressCallbackId: Int
+        var pressNodeId: Int
 
         /// Root defaults — mirror the leaf path (16pt, regular, black, no dark
         /// override, no custom font, no decoration/kerning/transform).
         static let root = RunContext(
             fontSize: 16, fontWeightInt: 0, fontFamilyInt: 0, fontName: "",
             colorArgb: 0xFF000000, darkColorArgb: 0, italic: false,
-            letterSpacingEm: 0, textTransform: 0
+            letterSpacingEm: 0, textTransform: 0, pressCallbackId: 0, pressNodeId: 0
         )
     }
 
@@ -138,6 +140,16 @@ struct NativeUITextRenderer: View {
             // string wraps at the container width and grows vertically.
             .frame(maxWidth: .infinity, alignment: frameAlignment(from: p.getInt("text_align")))
             .fixedSize(horizontal: false, vertical: true)
+            // Taps on pressable runs arrive as our custom-scheme link;
+            // anything else keeps the system's URL behaviour.
+            .environment(\.openURL, OpenURLAction { url in
+                guard url.scheme == "nativephp-press" else { return .systemAction }
+                let parts = url.pathComponents.filter { $0 != "/" }
+                if parts.count == 2, let cb = Int(parts[0]), let nodeId = Int(parts[1]), cb != 0 {
+                    NativeElementBridge.sendPressEvent(cb, nodeId: nodeId)
+                }
+                return .handled
+            })
     }
 
     /// Build the composed attributed string outside the `@ViewBuilder` — the
@@ -165,6 +177,13 @@ struct NativeUITextRenderer: View {
         ctx.italic = p.getInt("font_style", default: inherited.italic ? 1 : 0) == 1
         ctx.letterSpacingEm = p.getFloat("letter_spacing", default: inherited.letterSpacingEm)
         ctx.textTransform = p.getInt("text_transform", default: inherited.textTransform)
+
+        // The innermost @press wins for this run and everything under it,
+        // mirroring the Android renderer's link-wrapped subtree.
+        if node.onPress != 0 {
+            ctx.pressCallbackId = node.onPress
+            ctx.pressNodeId = node.id
+        }
 
         let ownText = p.getString("text")
         if !ownText.isEmpty {
@@ -227,6 +246,13 @@ struct NativeUITextRenderer: View {
             if node.props.getInt("line_through") == 1 { run.strikethroughStyle = .single }
         }
         if ctx.letterSpacingEm != 0 { run.kern = CGFloat(ctx.letterSpacingEm) * CGFloat(ctx.fontSize) }
+
+        // A pressable run rides a custom-scheme link; composedBody's
+        // OpenURLAction intercepts it and fires the ordinary press
+        // event, so PHP sees the same dispatch a standalone tap sends.
+        if ctx.pressCallbackId != 0 {
+            run.link = URL(string: "nativephp-press://run/\(ctx.pressCallbackId)/\(ctx.pressNodeId)")
+        }
 
         return run
     }

--- a/resources/ios/NativeUITextRenderer.swift
+++ b/resources/ios/NativeUITextRenderer.swift
@@ -141,7 +141,7 @@ struct NativeUITextRenderer: View {
             .frame(maxWidth: .infinity, alignment: frameAlignment(from: p.getInt("text_align")))
             .fixedSize(horizontal: false, vertical: true)
             // Taps on pressable runs arrive as our custom-scheme link;
-            // anything else keeps the system's URL behaviour.
+            // every other URL keeps the system's own behaviour.
             .environment(\.openURL, OpenURLAction { url in
                 guard url.scheme == "nativephp-press" else { return .systemAction }
                 let parts = url.pathComponents.filter { $0 != "/" }
@@ -178,8 +178,8 @@ struct NativeUITextRenderer: View {
         ctx.letterSpacingEm = p.getFloat("letter_spacing", default: inherited.letterSpacingEm)
         ctx.textTransform = p.getInt("text_transform", default: inherited.textTransform)
 
-        // The innermost @press wins for this run and everything under it,
-        // mirroring the Android renderer's link-wrapped subtree.
+        // The innermost @press wins for this run and its whole subtree,
+        // matching the flat per-span links the Android renderer emits.
         if node.onPress != 0 {
             ctx.pressCallbackId = node.onPress
             ctx.pressNodeId = node.id
@@ -247,9 +247,9 @@ struct NativeUITextRenderer: View {
         }
         if ctx.letterSpacingEm != 0 { run.kern = CGFloat(ctx.letterSpacingEm) * CGFloat(ctx.fontSize) }
 
-        // A pressable run rides a custom-scheme link; composedBody's
-        // OpenURLAction intercepts it and fires the ordinary press
-        // event, so PHP sees the same dispatch a standalone tap sends.
+        // A pressable run rides a custom-scheme link that composedBody's
+        // OpenURLAction intercepts and forwards as an ordinary press,
+        // so PHP sees the same dispatch a standalone tap sends.
         if ctx.pressCallbackId != 0 {
             run.link = URL(string: "nativephp-press://run/\(ctx.pressCallbackId)/\(ctx.pressNodeId)")
         }


### PR DESCRIPTION
Fixes NativePHP/mobile-air#339. A `<text @press>` inside another `<text>` rendered fine but taps did nothing. A standalone `<text @press>` worked.

The PHP side turned out to be innocent. The nested run crosses the wire with a live `on_press` callback id, and firing that callback from the test suite runs the handler. Press handling on native is attached per node view by `NodeGestureModifier`, and the text renderers never create views for their text children. They fold them into one attributed string, so the `onPress` sitting on the run node was never read. Same on both platforms.

The fix uses each platform's inline link mechanism, which already hit-tests taps inside a wrapped paragraph, and calls the same `sendPressEvent` every other renderer here calls. PHP receives an ordinary press. No core changes, no wire changes.

On Android every span emitted under a pressable run gets its own `LinkAnnotation.Clickable`, so annotation ranges stay flat instead of nesting when a pressable sits inside a pressable. I carry the run's own text decoration into the link styles, because with `styles = null` Compose underlined the range like a hyperlink.

On iOS the innermost `@press` travels down through `RunContext`, pressable runs get a custom scheme `run.link`, and `composedBody` intercepts it with an `OpenURLAction`. Real URLs still fall through to the system. The run's explicit `foregroundColor` keeps the authored color instead of the link tint.

Both platforms resolve the press target the same way, down through the run context: a styled sub-run inside a pressable run stays tappable, and the innermost `@press` wins. Long-press and the other gesture callbacks stay out of scope here, link annotations are tap-only primitives, and wiring those needs a different mechanism. Today they silently do nothing on runs, same as `@press` did before this.

Verified with a counter screen on both:

| | before | after |
| --- | --- | --- |
| Android emulator | nested stayed 0 | nested=3 from 3 taps |
| iOS simulator | nested stayed 0 | nested=6 from 6 taps |

Styling checked too: authored color and weight survive, no underline, no accent tint.

Press inside press is verified as well, on both platforms: a tap on the inner pressable fires only the inner handler, the outer one fires on its own words, innermost wins. On Android that was outer=2 inner=2 from exactly two taps on each region, on iOS the same by hand.

No automated test in here, and that's deliberate. `Native::test()` passes on the broken build, it dispatches by callback id against the PHP tree and never touches a renderer, so it can't see this class of bug. A real regression test needs to drive the native side.

Jump ships these renderers precompiled, so the fix reaches the reporter with the next Jump release, not with a composer update.
