### PR TITLE
fix(android): mask secure input in BareTextInputRenderer

### DIFF
--- a/resources/android/BareTextInputRenderer.kt
+++ b/resources/android/BareTextInputRenderer.kt
@@ -146,6 +146,7 @@ object BareTextInputRenderer {
                 }
             ),
             singleLine = !props.multiline,
+            visualTransformation = props.visualTransformation,
             decorationBox = { innerTextField ->
                 if (value.text.isEmpty() && props.placeholder.isNotEmpty()) {
                     Text(


### PR DESCRIPTION
On Android, `secure` has no effect on `<native:bare-text-input>` — the password renders in the clear.

`BareTextInputRenderer` builds its own `BasicTextField` and never passes `visualTransformation`, so the `secure` prop is parsed into `TextInputProps` (`TextInputShared.kt:112`) and mapped to `PasswordVisualTransformation()` (`TextInputShared.kt:75-76`), but never reaches the field.

### Changes
* Injected `visualTransformation = props.visualTransformation` into the `BasicTextField` constructor. No new import — the property is already typed on `TextInputProps`.

### Notes
* The outlined and filled renderers already pass it (`OutlinedTextInputRenderer.kt:157`, `FilledTextInputRenderer.kt:144`).
* iOS is unaffected — its bare renderer delegates to `NativeUITextInputCore`.
* Same class of omission as #51 (props parsed, never wired), different argument. Placed next to `singleLine` to avoid conflicting with that PR.
* `keyboard="password"` does not substitute: `KeyboardType.Password` is an IME hint, not a display transform.