### PR TITLE
feat(ios): mirror the side drawer for right-to-left layouts

### DIFF
--- a/resources/ios/NativeUIDrawerHost.swift
+++ b/resources/ios/NativeUIDrawerHost.swift
@@ -65,9 +65,22 @@ struct NativeDrawerHost<Content: View>: View {
 
     @ObservedObject private var state = DrawerHostState.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.layoutDirection) private var layoutDirection
     @State private var dragOffset: CGFloat = 0
 
     private let edgeSwipeThreshold: CGFloat = 30
+
+    /// Whether the layout direction is right-to-left. When true, the drawer
+    /// lives on the trailing edge and every physical offset / gesture sign is
+    /// inverted — logical `.leading`/`.trailing` alignment alone does not
+    /// mirror `.offset(x:)` math or drag-translation signs.
+    private var isRTL: Bool { layoutDirection == .rightToLeft }
+
+    /// +1 in LTR, -1 in RTL — the direction content moves to reveal the drawer.
+    private var openSign: CGFloat { isRTL ? -1 : 1 }
+
+    /// The edge the drawer is pinned to and slides from.
+    private var drawerAlignment: Alignment { isRTL ? .trailing : .leading }
 
     /// Slide animation for the drawer. Suppressed when the user has Reduce
     /// Motion enabled — open/close state then applies instantly instead of
@@ -116,37 +129,41 @@ struct NativeDrawerHost<Content: View>: View {
 
             let edgeSwipe = DragGesture(minimumDistance: 10)
                 .onChanged { value in
-                    guard !state.isOpen,
-                          value.startLocation.x < edgeSwipeThreshold,
-                          value.translation.width > 0 else { return }
-                    dragOffset = min(value.translation.width, drawerWidth)
+                    guard !state.isOpen else { return }
+                    let delta = openSign * value.translation.width
+                    guard delta > 0 else { return }
+                    dragOffset = min(delta, drawerWidth)
                 }
                 .onEnded { value in settleOpen(value: value, width: drawerWidth) }
 
             let closeDrag = DragGesture()
                 .onChanged { value in
-                    guard state.isOpen, value.translation.width < 0 else { return }
-                    dragOffset = max(value.translation.width, -drawerWidth)
+                    guard state.isOpen else { return }
+                    let delta = openSign * value.translation.width
+                    guard delta < 0 else { return }
+                    dragOffset = max(delta, -drawerWidth)
                 }
                 .onEnded { value in settleClose(value: value, width: drawerWidth) }
 
-            ZStack(alignment: .leading) {
+            ZStack(alignment: drawerAlignment) {
                 if isReveal {
-                    // Drawer pinned at the left edge, behind the content.
+                    // Drawer pinned at the leading edge (left in LTR, right in
+                    // RTL), behind the content.
                     drawerView(drawerNode, width: drawerWidth)
                         .zIndex(0)
 
-                    // Content slides right to expose the drawer. No scrim
-                    // dims the drawer; a transparent catcher over the pushed-
-                    // aside content closes the drawer on tap / drag.
+                    // Content slides aside (right in LTR, left in RTL) to
+                    // expose the drawer. No scrim dims the drawer; a
+                    // transparent catcher over the pushed-aside content closes
+                    // the drawer on tap / drag.
                     content
-                        .offset(x: openWidth)
+                        .offset(x: openSign * openWidth)
                         .zIndex(1)
 
                     if state.isOpen {
                         Color.clear
                             .contentShape(Rectangle())
-                            .offset(x: openWidth)
+                            .offset(x: openSign * openWidth)
                             .onTapGesture { animateClosed() }
                             .gesture(closeDrag)
                             .zIndex(2)
@@ -166,19 +183,21 @@ struct NativeDrawerHost<Content: View>: View {
                     }
 
                     drawerView(drawerNode, width: drawerWidth)
-                        .offset(x: openWidth - drawerWidth)
+                        .offset(x: openSign * (openWidth - drawerWidth))
                         .gesture(closeDrag)
                         .zIndex(2)
                 }
 
-                // Left-edge detector for swipe-to-open (both modes), when closed.
+                // Edge detector for swipe-to-open (both modes), when closed.
+                // Positioned at the leading edge (LTR) or trailing edge (RTL).
                 if !state.isOpen {
                     Color.clear
                         .frame(width: edgeSwipeThreshold)
                         .frame(maxHeight: .infinity)
                         .contentShape(Rectangle())
+                        .frame(maxWidth: .infinity, alignment: drawerAlignment)
                         .gesture(edgeSwipe)
-                        .ignoresSafeArea(edges: .leading)
+                        .ignoresSafeArea(edges: isRTL ? .trailing : .leading)
                         .zIndex(3)
                 }
 
@@ -232,8 +251,11 @@ struct NativeDrawerHost<Content: View>: View {
     // MARK: - Gesture settling
 
     private func settleOpen(value: DragGesture.Value, width: CGFloat) {
-        let velocity = value.predictedEndTranslation.width - value.translation.width
-        let opened = value.translation.width > width * 0.3 || velocity > 300
+        // `openSign *` maps both directions onto the "open" axis so the
+        // threshold and velocity checks stay direction-agnostic.
+        let delta = openSign * value.translation.width
+        let velocity = openSign * (value.predictedEndTranslation.width - value.translation.width)
+        let opened = delta > width * 0.3 || velocity > 300
         withAnimation(drawerAnimation) {
             state.isOpen = opened
             dragOffset = 0
@@ -241,8 +263,9 @@ struct NativeDrawerHost<Content: View>: View {
     }
 
     private func settleClose(value: DragGesture.Value, width: CGFloat) {
-        let velocity = value.predictedEndTranslation.width - value.translation.width
-        let closed = abs(value.translation.width) > width * 0.3 || velocity < -300
+        let delta = openSign * value.translation.width
+        let velocity = openSign * (value.predictedEndTranslation.width - value.translation.width)
+        let closed = abs(delta) > width * 0.3 || velocity < -300
         withAnimation(drawerAnimation) {
             state.isOpen = !closed
             dragOffset = 0


### PR DESCRIPTION
## Summary

Mirrors the iOS side drawer for right-to-left layouts. This is the `mobile-ui` companion to the opt-in RTL support landed in `nativephp/mobile-air` (PR #362).

`NativeUIDrawerHost` hand-rolls its geometry with physical `.offset(x:)` math and drag-translation signs. SwiftUI's `.layoutDirection` environment does **not** mirror those — it only flips logical `.leading`/`.trailing` alignment. As a result, when core sets `.environment(\.layoutDirection, .rightToLeft)`:

- the ☰ affordance flips to the top-right (`.topLeading` + `.padding(.leading)` are logical), but
- the drawer would still slide in from the **left**, and the edge-swipe would still require a **left-edge** drag — a visual/gesture mismatch.

## Changes

`NativeUIDrawerHost.swift` now reads `@Environment(\.layoutDirection)` and inverts every physical direction:

- Drawer pins to `.leading` (LTR) / `.trailing` (RTL) via a derived `drawerAlignment`.
- Content slide and the modal drawer slide use an `openSign` (+1 LTR / -1 RTL).
- Edge-swipe-to-open and drag-to-close use direction-agnostic translation checks.
- The edge detector strip is positioned at the leading/trailing edge and its `ignoresSafeArea` edge follows the direction.
- `settleOpen`/`settleClose` map translation + predicted velocity onto the "open" axis, so threshold and flick-velocity checks are direction-agnostic.

The ☰ button needs no change — its logical `.topLeading` / `.padding(.leading)` already flip and now line up with the mirrored drawer.

## Compatibility

- **LTR behavior is unchanged** (all signs reduce to the previous values when `openSign == 1`).
- One intentional correction: the swipe-to-open detector was previously a centered 30pt strip (missing edge alignment), so edge-swipes only registered from the screen center. It is now correctly positioned at the leading edge in LTR (and trailing in RTL), matching the existing "edge detector" comment and intent.

## Note on testing

`mobile-ui` CI runs PHP-only (`pint` + `pest`) and has no Swift test target for the renderers, so this change is validated by review rather than an automated native test.
