### PR TITLE
A secure field must never capitalize or autocorrect

### DIFF
--- a/resources/android/TextInputShared.kt
+++ b/resources/android/TextInputShared.kt
@@ -115,7 +115,7 @@ internal fun parseTextInputProps(node: NativeUINode): TextInputProps {
         minLines     = p.getInt("min_lines").let { if (it > 0) it else 1 },
         maxLength    = p.getInt("max_length"),
         keyboard     = resolveKeyboardType(p.getString("keyboard")),
-        capitalization = resolveCapitalization(p.getString("autocapitalize"), p.getString("keyboard")),
+        capitalization = resolveCapitalization(p.getString("autocapitalize"), p.getBool("secure"), p.getString("keyboard")),
         disabled     = p.getBool("disabled"),
         readOnly     = p.getBool("read_only"),
         isError      = p.getBool("is_error"),
@@ -171,13 +171,20 @@ internal fun resolveKeyboardType(kind: String): KeyboardType = when (kind.lowerc
 }
 
 /**
- * Capitalization from the explicit `autocapitalize` prop when the author set
- * one, otherwise derived from the keyboard type. Null means "leave Compose's
- * own default alone".
+ * Capitalization for the field. [secure] wins outright; otherwise the explicit
+ * `autocapitalize` prop when the author set one, otherwise derived from the
+ * keyboard type. Null means "leave Compose's own default alone".
  *
  * Compose already defaults to no capitalization, so Android never had the iOS
  * bug (mobile-air #304) — it got the right answer by accident rather than on
  * purpose, and `autocapitalize` had no way to take effect at all.
+ *
+ * [secure] is checked FIRST, ahead of the explicit prop. Compose's default
+ * already got an unannotated secure field right, so on Android this only
+ * closes the one hole the `autocapitalize` prop opened: an author setting
+ * `words` on a form and inheriting it onto the password field. Capitalizing a
+ * secret is never what was meant, and the field is masked, so the stray
+ * capital stays invisible until the login is rejected.
  *
  * The plain-text case deliberately returns NULL rather than `Sentences`.
  * Sentences is what iOS does and would make the platforms agree, but it would
@@ -188,8 +195,10 @@ internal fun resolveKeyboardType(kind: String): KeyboardType = when (kind.lowerc
  * Unknown values fall through to the derived behaviour rather than erroring,
  * matching `resolveKeyboardType`.
  */
-internal fun resolveCapitalization(explicit: String, keyboard: String): KeyboardCapitalization? =
-    when (explicit.lowercase()) {
+internal fun resolveCapitalization(explicit: String, secure: Boolean, keyboard: String): KeyboardCapitalization? {
+    if (secure) return KeyboardCapitalization.None
+
+    return when (explicit.lowercase()) {
         "none"       -> KeyboardCapitalization.None
         "sentences"  -> KeyboardCapitalization.Sentences
         "words"      -> KeyboardCapitalization.Words
@@ -201,6 +210,7 @@ internal fun resolveCapitalization(explicit: String, keyboard: String): Keyboard
             else -> null
         }
     }
+}
 
 internal fun keyboardOptionsFor(props: TextInputProps): KeyboardOptions =
     props.capitalization

--- a/resources/ios/NativeUITextInputCore.swift
+++ b/resources/ios/NativeUITextInputCore.swift
@@ -61,14 +61,16 @@ struct NativeUITextInputCore: View {
         let readOnly      = p.getBool("read_only")
         let keyboardKind  = p.getString("keyboard")
         let keyboard      = resolveKeyboardType(keyboardKind)
-        // Capitalization and autocorrect are derived from the keyboard type
-        // unless the author overrode them — declaring a field `email` should
-        // carry its typing behaviour, not just its key layout.
+        // Capitalization and autocorrect are derived from `secure` and the
+        // keyboard type unless the author overrode them — declaring a field
+        // `email` should carry its typing behavior, not just its key layout,
+        // and declaring one `secure` should carry the behavior a secret needs.
         let capitalization = resolveAutocapitalization(
             explicit: p.getString("autocapitalize"),
+            secure: secure,
             keyboard: keyboardKind
         )
-        let autocorrect   = allowsAutocorrection(keyboard: keyboardKind)
+        let autocorrect   = allowsAutocorrection(secure: secure, keyboard: keyboardKind)
         let onChangeCb    = p.getCallbackId("on_change")
         let onSubmitCb    = p.getCallbackId("on_submit")
         let syncMode      = p.getString("sync_mode", default: "live")
@@ -436,8 +438,9 @@ private func resolveKeyboardType(_ kind: String) -> UIKeyboardType {
     }
 }
 
-/// Capitalization for the field, from the explicit `autocapitalize` prop when
-/// the author set one, otherwise derived from the keyboard type.
+/// Capitalization for the field. `secure` wins outright; otherwise the
+/// explicit `autocapitalize` prop when the author set one, otherwise derived
+/// from the keyboard type.
 ///
 /// SwiftUI defaults an untouched TextField to `.sentences`, which is why an
 /// email field capitalized its first letter even though `.emailAddress` was
@@ -445,9 +448,20 @@ private func resolveKeyboardType(_ kind: String) -> UIKeyboardType {
 /// kind whose content is case-sensitive or non-alphabetic therefore has to opt
 /// out explicitly.
 ///
+/// A `secure` field is checked FIRST — ahead of the explicit prop, which is the
+/// only place in this resolver where the author's word is not final. A password
+/// is opaque bytes; there is no reading of `autocapitalize="sentences"` on a
+/// secret under which shifting its first character is what the author wanted,
+/// and the failure is silent (the field is masked, so the stray capital is
+/// invisible until the login is rejected). The element already suppresses
+/// selection reporting for secure fields at the source on the same reasoning —
+/// some invariants shouldn't be a prop away from being wrong.
+///
 /// Unknown `autocapitalize` values fall through to the derived behaviour rather
 /// than erroring — same policy as `resolveKeyboardType`.
-private func resolveAutocapitalization(explicit: String, keyboard: String) -> TextInputAutocapitalization {
+private func resolveAutocapitalization(explicit: String, secure: Bool, keyboard: String) -> TextInputAutocapitalization {
+    if secure { return .never }
+
     switch explicit.lowercased() {
     case "none":       return .never
     case "sentences":  return .sentences
@@ -473,7 +487,13 @@ private func resolveAutocapitalization(explicit: String, keyboard: String) -> Te
 /// Whether autocorrect should run. Same reasoning as capitalization: iOS will
 /// happily "correct" an email local part or a URL slug into a dictionary word,
 /// and the field type is enough to know that's unwanted.
-private func allowsAutocorrection(keyboard: String) -> Bool {
+///
+/// `secure` is the strongest case of all: a password is by definition not a
+/// dictionary word, so every suggestion is a wrong one, and the candidate bar
+/// over a masked field is also a place the secret can be shoulder-surfed.
+private func allowsAutocorrection(secure: Bool, keyboard: String) -> Bool {
+    if secure { return false }
+
     switch keyboard.lowercased() {
     case "email", "url", "number", "decimal", "phone", "numberpassword", "password":
         return false

--- a/src/Elements/BaseTextInput.php
+++ b/src/Elements/BaseTextInput.php
@@ -269,6 +269,9 @@ abstract class BaseTextInput extends Element
      *
      * Unknown values are ignored natively and fall back to the derived
      * behaviour rather than erroring.
+     *
+     * IGNORED on a `secure()` field, which always resolves to no
+     * capitalization (and no autocorrect). See `secure()`.
      */
     public function autocapitalize(string $mode): static
     {
@@ -277,6 +280,14 @@ abstract class BaseTextInput extends Element
         return $this;
     }
 
+    /**
+     * Mask the field's contents (password entry).
+     *
+     * Beyond masking, `secure` carries the typing behavior a secret needs:
+     * capitalization and autocorrect are both forced off natively, ahead of
+     * any `autocapitalize()` the author set, and `@selectionChange` is never
+     * serialized at all (see `onSelectionChange()`).
+     */
     public function secure(bool $value = true): static
     {
         $this->inputProps['secure'] = $value;


### PR DESCRIPTION

## The problem

`#47` derived capitalization and autocorrect from the keyboard type, which was
the right move. But both resolvers in `NativeUITextInputCore.swift` take only
the explicit `autocapitalize` prop and the keyboard kind:

```swift
resolveAutocapitalization(explicit: String, keyboard: String)
allowsAutocorrection(keyboard: String)
```

`secure` is a separate prop, and neither resolver looks at it. So this field:

```blade
<native:outlined-text-input label="Password" secure native:model="password" />
```

sets no `keyboard`, misses every case in the derived switch, and falls through
to `default: .sentences`. iOS shifts the first character of the password the
moment the user starts typing. `allowsAutocorrection` has the same shape and
the same hole, so the same field also gets autocorrect and a candidate bar.

## Why it matters

The field is masked, so neither failure is visible. The user types their
password, the login is rejected, and the natural conclusion is "I mistyped
it" — not "the field capitalized it for me". It reproduces on every attempt,
which makes it look like a wrong password rather than a bug.

Autocorrect is the worse half of the two. A password is by definition not a
dictionary word, so every suggestion iOS offers is a wrong one, and the
candidate bar renders the secret in the clear directly above a field that was
deliberately masked.

## The approach

`secure` short-circuits both resolvers:

```swift
resolveAutocapitalization(explicit: String, secure: Bool, keyboard: String)
allowsAutocorrection(secure: Bool, keyboard: String)
```

Note where the check sits: **before** the explicit `autocapitalize` prop. That
is the one place in this resolver where the author's word is not final, and it
is deliberate. There is no reading of `autocapitalize="sentences"` on a secret
under which shifting its first character is what was meant — the two props are
simply in contradiction, and one of them is about a password.

There is precedent for `secure` overriding rather than merging.
`BaseTextInput::resolveProps()` already refuses to serialize
`@selectionChange` for a secure input *at the source*, with the comment that
leaving it to the renderers "leaves a privacy-relevant invariant restated in
every renderer — including any future one". Same argument here.

Android is covered for parity, though it never showed the bug: Compose's
`KeyboardOptions` defaults to no capitalization, so an unannotated secure field
was already right. What it closes there is the hole `#47`'s new prop opened —
an author setting `autocapitalize="words"` on a form and inheriting it onto the
password field.

The PHP change is docblocks only: `autocapitalize()` now says it is ignored on
a secure field, and `secure()` now documents the behavior it carries.

## Alternatives considered

- **Leave the explicit prop winning.** Rejected: it makes `secure` advisory
  about the one thing it exists to be strict about, and the failure is silent.
  If someone genuinely wants a capitalizing masked field, `autocapitalize` is
  still there — they just have to not also say `secure`.
- **Map `secure` to `keyboardType(.asciiCapable)` or set
  `textContentType(.password)`.** Both are worth doing and neither fixes this:
  `keyboardType` sets the key layout only, which is exactly the discovery
  `#47` was built on. `textContentType` is a separate (and useful) change
  about AutoFill.
- **Disable autocorrect on Android too.** Not done here. Compose gates
  autocorrect behind a `KeyboardOptions` field this repo does not use yet, and
  the iOS candidate-bar problem does not have a like-for-like Android form. It
  is a separate change rather than a guess.

## What I verified / what I could not

Verified:

- **iOS type-checks against the real SDK.** All of `resources/ios/*.swift`
  compiled together with the core `NativeRender` sources from a real app
  install:
  `swiftc -typecheck -sdk $(xcrun --sdk iphonesimulator --show-sdk-path) -target arm64-apple-ios18.2-simulator`.
  Clean; no new warnings. (`NativeUIWebviewRenderer.swift` is excluded from
  that slice — it references app-target PHP-runtime symbols — and is untouched
  by this branch.)
- `php -l` on the changed PHP file; `pint --test` passes; the full Pest suite
  passes (217 tests, 735 assertions).

Could not verify:

- **No runtime/device test.** `mobile-ui@main` does not currently register
  most of its components against the released core: the manifest's `blade`
  paths say `Native\Mobile\Edge\Components\Text` while core ships
  `Native\Mobile\Edge\Components\Native\Text`. 25 of 59 entries fail
  `class_exists()` and are skipped silently, so `<button>` and every text
  input vanish from `ElementRegistry::all()` (52 components → 27). I could not
  build a working app against this branch to type into. Happy to file that
  separately with the measurements if it is not already known.
- **Android is compile-unverified.** No Kotlin toolchain here; the change is
  a signature extension and one early return.
