### PR TITLE
Add an in-field reveal toggle for secure inputs

### DIFF
--- a/resources/android/FilledTextInputRenderer.kt
+++ b/resources/android/FilledTextInputRenderer.kt
@@ -50,6 +50,12 @@ object FilledTextInputRenderer {
         var value by remember { mutableStateOf(TextFieldValue(props.serverValue, TextRange(props.serverValue.length))) }
         var lastSentValue by remember { mutableStateOf(props.serverValue) }
 
+        // Reveal state for a `revealable` secure field. Local on purpose, and
+        // that is the whole safety argument for the feature: flipping it never
+        // crosses the bridge, so it cannot republish the tree, disturb `value`
+        // / `lastSentValue`, trip the sync-mode dispatcher, or move the caret.
+        var revealed by remember { mutableStateOf(false) }
+
         val dispatcher = remember(props.syncMode, props.debounceMs, props.onChangeCb) {
             TextInputDispatcher(
                 scope = scope,
@@ -136,12 +142,20 @@ object FilledTextInputRenderer {
             leadingIcon = leadingIconSlot(props.leadingIcon),
             trailingIcon = if (props.loading) {
                 { CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = theme.onSurfaceVariant) }
-            } else trailingIconSlot(props.trailingIcon),
+            } else {
+                // The reveal toggle owns the trailing slot whenever it is on.
+                // An author who set a trailing icon AND `revealable` asked for
+                // the toggle by asking for `revealable`, which the icon slot
+                // has no other way to express; the icon is still drawn on
+                // every field that didn't.
+                revealToggleSlot(props, revealed) { revealed = !revealed }
+                    ?: trailingIconSlot(props.trailingIcon)
+            },
             isError = props.isError,
             singleLine = props.singleLine,
             maxLines = props.maxLines,
             minLines = props.minLines,
-            visualTransformation = props.visualTransformation,
+            visualTransformation = props.visualTransformation(revealed),
             keyboardOptions = keyboardOptionsFor(props),
             keyboardActions = KeyboardActions(onDone = {
                 // Flush the settled caret before the submit event fires.

--- a/resources/android/OutlinedTextInputRenderer.kt
+++ b/resources/android/OutlinedTextInputRenderer.kt
@@ -54,6 +54,12 @@ object OutlinedTextInputRenderer {
         var value by remember { mutableStateOf(TextFieldValue(props.serverValue, TextRange(props.serverValue.length))) }
         var lastSentValue by remember { mutableStateOf(props.serverValue) }
 
+        // Reveal state for a `revealable` secure field. Local on purpose, and
+        // that is the whole safety argument for the feature: flipping it never
+        // crosses the bridge, so it cannot republish the tree, disturb `value`
+        // / `lastSentValue`, trip the sync-mode dispatcher, or move the caret.
+        var revealed by remember { mutableStateOf(false) }
+
         // Sync-mode dispatcher (plan L). Owns the live / blur / debounce
         // decision for outbound change events.
         val dispatcher = remember(props.syncMode, props.debounceMs, props.onChangeCb) {
@@ -149,12 +155,20 @@ object OutlinedTextInputRenderer {
             leadingIcon = leadingIconSlot(props.leadingIcon),
             trailingIcon = if (props.loading) {
                 { CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp, color = theme.onSurfaceVariant) }
-            } else trailingIconSlot(props.trailingIcon),
+            } else {
+                // The reveal toggle owns the trailing slot whenever it is on.
+                // An author who set a trailing icon AND `revealable` asked for
+                // the toggle by asking for `revealable`, which the icon slot
+                // has no other way to express; the icon is still drawn on
+                // every field that didn't.
+                revealToggleSlot(props, revealed) { revealed = !revealed }
+                    ?: trailingIconSlot(props.trailingIcon)
+            },
             isError = props.isError,
             singleLine = props.singleLine,
             maxLines = props.maxLines,
             minLines = props.minLines,
-            visualTransformation = props.visualTransformation,
+            visualTransformation = props.visualTransformation(revealed),
             keyboardOptions = keyboardOptionsFor(props),
             keyboardActions = KeyboardActions(onDone = {
                 // Flush the settled caret before the submit event fires.

--- a/resources/android/TextInputShared.kt
+++ b/resources/android/TextInputShared.kt
@@ -1,6 +1,7 @@
 package com.nativephp.plugins.native_ui.ui
 
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -46,6 +47,7 @@ internal data class TextInputProps(
     val leadingIcon: String,
     val trailingIcon: String,
     val secure: Boolean,
+    val revealable: Boolean,
     val multiline: Boolean,
     val maxLines: Int,
     val minLines: Int,
@@ -72,8 +74,28 @@ internal data class TextInputProps(
     val selectionDebounceMs: Int,
 ) {
     val enabled: Boolean get() = !disabled && !loading
+
+    /**
+     * Masking for a field that may currently be revealed. The no-argument
+     * property is the always-masked case, which is what the chromeless
+     * variant uses — it has no decoration slot to put a toggle in, so it can
+     * never be revealed.
+     */
+    fun visualTransformation(revealed: Boolean): VisualTransformation =
+        if (secure && !revealed) PasswordVisualTransformation() else VisualTransformation.None
+
     val visualTransformation: VisualTransformation
-        get() = if (secure) PasswordVisualTransformation() else VisualTransformation.None
+        get() = visualTransformation(revealed = false)
+
+    /**
+     * Whether to draw the in-field reveal toggle. Opt-in via `revealable`,
+     * meaningless without `secure`, and suppressed while the field is not
+     * interactive — there is nothing to reveal in a field the user cannot
+     * type into, and a disabled control that still answers taps is its own
+     * bug.
+     */
+    val revealToggle: Boolean get() = secure && revealable && enabled && !readOnly
+
     val singleLine: Boolean get() = !multiline
 
     /** Numeric sp size for the chromeless variant. Tracks token fallbacks. */
@@ -110,6 +132,7 @@ internal fun parseTextInputProps(node: NativeUINode): TextInputProps {
         leadingIcon  = p.getString("leading_icon"),
         trailingIcon = p.getString("trailing_icon"),
         secure       = p.getBool("secure"),
+        revealable   = p.getBool("revealable"),
         multiline    = p.getBool("multiline"),
         maxLines     = p.getInt("max_lines").let { if (it > 0) it else if (p.getBool("multiline")) 5 else 1 },
         minLines     = p.getInt("min_lines").let { if (it > 0) it else 1 },
@@ -414,6 +437,38 @@ internal fun leadingIconSlot(name: String): (@Composable () -> Unit)? =
 @Composable
 internal fun trailingIconSlot(name: String): (@Composable () -> Unit)? =
     if (name.isEmpty()) null else ({ MaterialIcon(name = name, contentDescription = null) })
+
+/**
+ * The in-field reveal ("eye") for a `secure` field, for the M3 `trailingIcon`
+ * slot — so it sits where the trailing icon sits rather than as a separate
+ * Show / Hide control beside the input, which is what an app has to build
+ * today and which costs a bridge round-trip and a republish on every tap.
+ *
+ * [revealed] is caller-owned local state and stays local: it must never be
+ * reported to PHP, republish the tree, or touch the value / caret / sync-mode
+ * machinery. Returns null when the field didn't ask for a toggle, so the
+ * caller's existing trailing slot is used unchanged.
+ *
+ * The content description announces the ACTION the tap performs rather than
+ * the current state — TalkBack reads "Show password, button".
+ */
+@Composable
+internal fun revealToggleSlot(
+    props: TextInputProps,
+    revealed: Boolean,
+    onToggle: () -> Unit,
+): (@Composable () -> Unit)? {
+    if (!props.revealToggle) return null
+
+    return {
+        IconButton(onClick = onToggle) {
+            MaterialIcon(
+                name = if (revealed) "visibility_off" else "visibility",
+                contentDescription = if (revealed) "Hide password" else "Show password",
+            )
+        }
+    }
+}
 
 /**
  * Apply optional a11y label/hint to a modifier.

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -28,6 +28,12 @@ paths serialize to the same wire tree.
 - Each `@selectionChange` event carries the FULL current text and costs a
   component re-render, independent of the `native:model` sync mode — don't
   reach for it when plain `@change` would do.
+- Add `revealable` alongside `secure` for the in-field eye that lets the user
+  check what they typed. It is native-only — tapping it never round-trips to
+  PHP and never touches the bound value — so don't hand-roll a Show / Hide
+  button bound to a component property. Honored on `outlined-text-input` and
+  `filled-text-input`; `bare-text-input` draws no chrome, so supply your own
+  control there.
 - `<native:date-picker>` handles dates, times, and both. Set `mode` to
   `date` (default), `time`, or `datetime`. Values are always wall-clock ISO
   strings — `2026-07-25`, `14:30`, `2026-07-25T14:30` — never offsets or

--- a/resources/ios/NativeUIFilledTextInputRenderer.swift
+++ b/resources/ios/NativeUIFilledTextInputRenderer.swift
@@ -82,7 +82,8 @@ struct NativeUIFilledTextInputRenderer: View {
                         node: node,
                         textSize: metrics.textSize,
                         contentColor: disabled ? theme.onSurface.opacity(0.6) : theme.onSurface,
-                        tintColor: isError ? theme.destructive : theme.primary
+                        tintColor: isError ? theme.destructive : theme.primary,
+                        supportsRevealToggle: true
                     )
                     .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/resources/ios/NativeUIOutlinedTextInputRenderer.swift
+++ b/resources/ios/NativeUIOutlinedTextInputRenderer.swift
@@ -83,7 +83,8 @@ struct NativeUIOutlinedTextInputRenderer: View {
                     node: node,
                     textSize: metrics.textSize,
                     contentColor: disabled ? theme.onSurface.opacity(0.6) : theme.onSurface,
-                    tintColor: isError ? theme.destructive : theme.primary
+                    tintColor: isError ? theme.destructive : theme.primary,
+                    supportsRevealToggle: true
                 )
                 .frame(maxWidth: .infinity, alignment: .leading)
 

--- a/resources/ios/NativeUITextInputCore.swift
+++ b/resources/ios/NativeUITextInputCore.swift
@@ -569,7 +569,24 @@ private struct RevealToggleModifier: ViewModifier {
                     Image(systemName: revealed ? "eye.slash.fill" : "eye.fill")
                         .nuiScaledFont(size: max(13, textSize - 2))
                         .foregroundStyle(contentColor.opacity(0.85))
-                        .nuiMinTapTarget()
+                        // Deliberately NOT `.nuiMinTapTarget()`. That puts a
+                        // `minHeight: 44` on the icon, and this HStack sits
+                        // INSIDE the field's content — the variant renderer adds
+                        // its own vertical padding around the whole thing — so a
+                        // 44pt floor here makes a revealable field far taller
+                        // than a plain one. Measured on a login form: 42.7pt for
+                        // the email field, 64.7pt for the password field beside
+                        // it. Half again as tall, and it reads as a layout bug.
+                        //
+                        // `maxHeight: .infinity` fills the row rather than
+                        // demanding a height, so the field keeps exactly the
+                        // height it had before it grew an eye (re-measured at
+                        // 40.7pt, matching the same field with the toggle off).
+                        // The tap target is still >= 44 wide by the full height
+                        // of the field, and `contentShape` keeps all of that
+                        // tappable instead of just the glyph.
+                        .frame(minWidth: 44, maxHeight: .infinity)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 // Announce the ACTION the tap performs, not the current state.

--- a/resources/ios/NativeUITextInputCore.swift
+++ b/resources/ios/NativeUITextInputCore.swift
@@ -8,7 +8,7 @@ import UIKit
 ///     value we sent out)
 ///   - `sync_mode` dispatch policy (live | debounce | blur) — controlled by
 ///     the `native:model` directive modifier chain
-///   - secure / multiline input
+///   - secure / multiline input, with an optional in-field reveal toggle
 ///   - keyboard type, submit label
 ///   - disabled / readOnly state
 ///   - onChange / onSubmit callbacks
@@ -21,10 +21,29 @@ struct NativeUITextInputCore: View {
     let contentColor: Color
     let tintColor: Color
 
+    /// Whether this variant has room to draw the `revealable` eye INSIDE the
+    /// field. The chrome variants (outlined, filled) pass true; the chromeless
+    /// one does not, because its whole contract is that it draws no decoration
+    /// of its own — an author using it supplies their own trailing control.
+    /// Defaulted so the bare renderer's call site stays as it was, and so the
+    /// prop is honored on exactly the same two variants on both platforms
+    /// (Android's toggle lives in the M3 `trailingIcon` slot, which the
+    /// chromeless `BasicTextField` doesn't have).
+    var supportsRevealToggle: Bool = false
+
     @State private var text: String = ""
     @State private var lastSentValue: String = ""
     @State private var initialized: Bool = false
     @State private var debounceTask: Task<Void, Never>? = nil
+    /// Whether a `secure` field is currently showing its contents.
+    ///
+    /// Local `@State` on purpose, and that is the whole safety argument for
+    /// this feature: toggling it never crosses the bridge, so it cannot
+    /// republish the tree, cannot perturb `text` / `lastSentValue`, cannot
+    /// trip the `sync_mode` state machine, and cannot move the caret. Reveal
+    /// state is also the kind of thing that must not be persisted or
+    /// round-tripped anywhere near a password.
+    @State private var revealed: Bool = false
     @FocusState private var isFocused: Bool
 
     // ─── Selection / caret reporting (opt-in via `on_selection_change`) ──────
@@ -59,6 +78,16 @@ struct NativeUITextInputCore: View {
         let minLines      = p.getInt("min_lines")
         let disabled      = p.getBool("disabled")
         let readOnly      = p.getBool("read_only")
+        // The in-field eye. Only on a secure field, only where the variant has
+        // chrome to host it, and only while the field is interactive — there
+        // is nothing to reveal in a field the user cannot type into, and a
+        // disabled control that still responds to taps is its own bug.
+        let revealToggle  = supportsRevealToggle
+            && secure
+            && p.getBool("revealable")
+            && !(disabled || readOnly)
+        // A secure field is masked unless the user has revealed it.
+        let masked        = secure && !revealed
         let keyboardKind  = p.getString("keyboard")
         let keyboard      = resolveKeyboardType(keyboardKind)
         // Capitalization and autocorrect are derived from the keyboard type
@@ -99,10 +128,21 @@ struct NativeUITextInputCore: View {
         Group {
             if secure {
                 // SecureField has no selection binding — caret reporting is
-                // intentionally never available for secure fields.
-                SecureField(placeholder, text: $text)
-                    .foregroundColor(contentColor)
-                    .focused($isFocused)
+                // intentionally never available for secure fields. That holds
+                // for the revealed branch too: `selectionEnabled` is gated on
+                // `!secure`, so an unmasked password still reports nothing.
+                if masked {
+                    SecureField(placeholder, text: $text)
+                        .foregroundColor(contentColor)
+                        .focused($isFocused)
+                } else {
+                    // SecureField has no unmasked mode, so revealing means
+                    // swapping in a plain TextField. `multiline` is ignored on
+                    // a secure field in both branches, as before.
+                    TextField(placeholder, text: $text)
+                        .foregroundColor(contentColor)
+                        .focused($isFocused)
+                }
             } else if multiline {
                 // A vertical-axis TextField reports a ~0 intrinsic width when
                 // empty and won't expand to fill an ancestor's `maxWidth:
@@ -247,6 +287,16 @@ struct NativeUITextInputCore: View {
                 DispatchQueue.main.async { isFocused = true }
             }
         }
+        // Appended rather than woven in: when the toggle is off this modifier
+        // returns its content untouched, so every field that doesn't ask for
+        // an eye keeps the exact view tree it had.
+        .modifier(RevealToggleModifier(
+            enabled: revealToggle,
+            revealed: $revealed,
+            isFocused: $isFocused,
+            textSize: textSize,
+            contentColor: contentColor
+        ))
     }
 
     // ─── Dispatch policy ─────────────────────────────────────────────────────
@@ -479,5 +529,55 @@ private func allowsAutocorrection(keyboard: String) -> Bool {
         return false
     default:
         return true
+    }
+}
+
+/// Places the reveal ("eye") control inside the field's own chrome, so it sits
+/// where the trailing icon sits rather than as a separate Show / Hide control
+/// next to the input — which is what an app has to build today, and which
+/// costs a bridge round-trip and a republish on every tap.
+///
+/// Disabled, this returns `content` unchanged: no HStack, no wrapper, nothing
+/// added to the view tree. Every existing field therefore lays out exactly as
+/// it did.
+private struct RevealToggleModifier: ViewModifier {
+    let enabled: Bool
+    @Binding var revealed: Bool
+    var isFocused: FocusState<Bool>.Binding
+    let textSize: CGFloat
+    let contentColor: Color
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if enabled {
+            HStack(spacing: 6) {
+                content
+                Button {
+                    // Read focus BEFORE the swap: flipping `revealed` changes
+                    // which branch of the field is built, and SwiftUI treats
+                    // SecureField and TextField as different views, so the
+                    // one that had first responder is torn down and focus is
+                    // dropped. Re-assert it on the next runloop turn — after
+                    // the new field exists — or the keyboard drops away on
+                    // every tap of the eye.
+                    let wasFocused = isFocused.wrappedValue
+                    revealed.toggle()
+                    if wasFocused {
+                        DispatchQueue.main.async { isFocused.wrappedValue = true }
+                    }
+                } label: {
+                    Image(systemName: revealed ? "eye.slash.fill" : "eye.fill")
+                        .nuiScaledFont(size: max(13, textSize - 2))
+                        .foregroundStyle(contentColor.opacity(0.85))
+                        .nuiMinTapTarget()
+                }
+                .buttonStyle(.plain)
+                // Announce the ACTION the tap performs, not the current state.
+                // VoiceOver reads this as "Show password, button".
+                .accessibilityLabel(revealed ? "Hide password" : "Show password")
+            }
+        } else {
+            content
+        }
     }
 }

--- a/src/Elements/BaseTextInput.php
+++ b/src/Elements/BaseTextInput.php
@@ -19,7 +19,7 @@ use Native\Mobile\Icon\IosSymbol;
  * Allowed per-instance:
  *   - `value`, `placeholder`, `label`, `supporting`  (content)
  *   - `disabled`, `readOnly`, `error`, `loading`     (state)
- *   - `keyboard`, `autocapitalize`, `secure`, `maxLength`, `multiline`, `maxLines`, `minLines` (behavior)
+ *   - `keyboard`, `autocapitalize`, `secure`, `revealable`, `maxLength`, `multiline`, `maxLines`, `minLines` (behavior)
  *   - `prefix`, `suffix`, `leading-icon`, `trailing-icon` (decorations)
  *   - `size`                                          (sm | md | lg)
  *   - `a11y-label`, `a11y-hint`                       (accessibility)
@@ -91,6 +91,9 @@ abstract class BaseTextInput extends Element
         }
         if (! empty($attrs['secure'])) {
             $this->secure();
+        }
+        if (! empty($attrs['revealable'])) {
+            $this->revealable();
         }
         if (isset($attrs['maxLength']) || isset($attrs['max-length'])) {
             $this->maxLength((int) ($attrs['maxLength'] ?? $attrs['max-length']));
@@ -280,6 +283,29 @@ abstract class BaseTextInput extends Element
     public function secure(bool $value = true): static
     {
         $this->inputProps['secure'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Draw a reveal ("eye") toggle inside a `secure()` field, so the user can
+     * check what they typed without the app building a separate Show / Hide
+     * control beside the input.
+     *
+     * The toggle is entirely native: tapping it never crosses the bridge, so
+     * it cannot disturb the bound value, the caret, or the `native:model`
+     * sync mode. The revealed state is local to the field and is deliberately
+     * not reported to PHP.
+     *
+     * Opt-in, and a no-op without `secure()`. Honored by `outlined-text-input`
+     * and `filled-text-input`; ignored by `bare-text-input`, whose contract is
+     * that it draws no chrome of its own — supply your own control there.
+     *
+     * Blade: `revealable`.
+     */
+    public function revealable(bool $value = true): static
+    {
+        $this->inputProps['revealable'] = $value;
 
         return $this;
     }

--- a/tests/CollectorElementsTest.php
+++ b/tests/CollectorElementsTest.php
@@ -211,6 +211,38 @@ it('still serializes the selection callback when secure is explicitly false', fu
     expect($registry->kind($props['on_selection_change']))->toBe('text_selection');
 });
 
+it('carries the reveal toggle from the Blade attribute', function (string $type) {
+    NativeElementCollector::leaf($type, [
+        'secure' => true,
+        'revealable' => true,
+    ]);
+
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['props']['revealable'])->toBeTrue();
+})->with(['bare_text_input', 'outlined_text_input', 'filled_text_input']);
+
+it('omits the reveal toggle when the attribute is absent', function () {
+    // Absence is what keeps every existing secure field looking the way it
+    // does — the renderers only draw the eye when the prop is present and
+    // true, so a serialized `false` would be indistinguishable but noisier.
+    NativeElementCollector::leaf('outlined_text_input', ['secure' => true]);
+
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['props'])->not->toHaveKey('revealable');
+});
+
+it('registers the reveal toggle via the fluent API', function () {
+    $props = OutlinedTextInput::make()
+        ->secure()
+        ->revealable()
+        ->toArray(new CallbackRegistry)['props'];
+
+    expect($props['secure'])->toBeTrue();
+    expect($props['revealable'])->toBeTrue();
+});
+
 it('registers selection change via the fluent API', function () {
     $registry = new CallbackRegistry;
     $props = OutlinedTextInput::make()


### PR DESCRIPTION

## The problem

There is no way to let a user check the password they just typed.

- There is no dedicated password element — the variants are Outlined, Filled
  and Bare, and `secure` is a bool on the shared `BaseTextInput`.
- `trailing-icon` renders as a bare `Image` (iOS) / `MaterialIcon` (Android)
  with no gesture attached.
- `BaseTextInput` exposes no trailing-press callback.

So the only route open to an app is a separate Show / Hide button beside the
input, bound to a component property.

## Why it matters

That workaround is worse than it looks. Every tap crosses the bridge, runs a
PHP handler, and republishes the tree — to flip a boolean that PHP has no
business knowing, next to a field PHP is specifically *not* told the contents
of. It also puts the control outside the field, where nobody looks for it,
because every platform password field puts it inside.

And the thing it works around is a real accessibility problem: a masked field
with no way to check it is hostile to anyone typing a long generated password
on a phone keyboard.

## The approach

`revealable`, opt-in, alongside `secure`:

```blade
<native:outlined-text-input label="Password" secure revealable native:model="password" />
```

```php
OutlinedTextInput::make()->secure()->revealable();
```

**The revealed flag is local native state on both platforms** — `@State` on
iOS, `remember { mutableStateOf }` on Android — and that is the whole safety
argument for the feature, not an implementation detail. Because it never
crosses the bridge it cannot republish the tree, cannot perturb `text` /
`lastSentValue`, cannot trip the `sync_mode` state machine, and cannot move
the caret. It is also not the sort of state that should be persisted or
round-tripped anywhere near a password.

**iOS re-asserts focus after the swap, deliberately.** `SecureField` has no
unmasked mode, so revealing means building a `TextField` instead; SwiftUI
treats those as different views, tears the old one down, and first responder
goes with it. Without re-asserting focus on the next runloop turn, the
keyboard drops away every time the eye is tapped. Reading `isFocused` *before*
the toggle matters for the same reason.

Selection reporting stays off throughout: `selectionEnabled` is gated on
`!secure`, so a revealed password reports no caret offsets either.

**The off path is byte-identical.** On iOS the toggle is appended as a
`ViewModifier` that returns its content untouched when disabled, rather than
woven into the existing chain — so a field that doesn't ask for an eye keeps
the exact view tree it had. On Android it is a `trailingIcon` slot builder
returning `null` in the same case.

## Two contract points that want a maintainer's opinion

**1. Honored on outlined + filled only; a documented no-op on bare.**
`bare-text-input` draws no chrome by contract, and on Android its
`BasicTextField` has no decoration slot to host a control at all. Rather than
let iOS quietly offer something Android cannot, the iOS core takes an explicit
`supportsRevealToggle` that only the two chrome variants pass. An author using
the chromeless variant is drawing their own decoration and can draw their own
eye.

**2. When on, the toggle takes the trailing slot ahead of `trailing-icon`.**
An author who set both asked for the toggle by asking for `revealable`, and
the icon slot has no other way to express it. A `loading` spinner still wins
over both — `revealToggle` is gated on the field being interactive.

## Alternatives considered

- **Make it the default rather than opt-in.** I would happily argue for this:
  a masked field with no way to check it is a usability and accessibility
  failure, and Safari's own password fields offer the reveal. But it is a
  visible change to every password input already shipped, and it deserves its
  own discussion rather than being smuggled in under a feature PR. Flipping
  the default later is a one-line change to the prop read.
- **A generic `@trailingIconTap` callback instead.** More general, and worse
  here: it routes a password-visibility toggle through PHP, which is the exact
  cost this removes, and it makes every app reimplement the focus-restoration
  dance.
- **Draw the eye in each variant renderer instead of the shared core.** The
  focus re-assertion needs `@FocusState`, which the core owns and does not
  expose. Three renderers would each need their own copy of the state and the
  runloop deferral.
- **Overlay the button on the field rather than putting it in an HStack.**
  Avoids any layout change at all, but long values then run underneath the
  eye. The HStack only exists when the feature is on.

## What I verified / what I could not

Verified:

- **iOS type-checks against the real SDK.** All of `resources/ios/*.swift`
  compiled together with the core `NativeRender` sources from a real app
  install:
  `swiftc -typecheck -sdk $(xcrun --sdk iphonesimulator --show-sdk-path) -target arm64-apple-ios18.2-simulator`.
  Clean; no new warnings.
- Full Pest suite passes (222 tests), including five new `CollectorElementsTest`
  cases: the Blade attribute across all three variants, the fluent API, and
  that the prop is **omitted** when not set (absence is what keeps every
  existing secure field unchanged).
- `pint --test` passes; `php -l` on the changed PHP.
- Icon names checked against the catalogs this repo ships:
  `eye.fill` / `eye.slash.fill` in `resources/icons/sf-symbols.json`,
  `visibility` / `visibility_off` in `resources/icons/material-icons.json`.

Could not verify — and this is the branch where it matters most:

- **No runtime test of the interaction.** The focus-restoration behavior, the
  keyboard not flapping on toggle, and whether the caret survives the
  `SecureField` → `TextField` swap are all things that need a device.
  `mobile-ui@main` does not currently register most of its components against
  the released core — the manifest's `blade` paths say
  `Native\Mobile\Edge\Components\Text` while core ships
  `Native\Mobile\Edge\Components\Native\Text`, so 25 of 59 entries fail
  `class_exists()` and are skipped silently, taking `<button>` and every text
  input with them (52 registered components → 27). I could not build an app
  against this branch to tap the eye in.

  The equivalent iOS behavior **is** running on a device in an app pinned to
  an older mobile-ui, which is where the shape of this came from — the focus
  re-assertion in particular exists because the keyboard visibly dropped
  without it. That is evidence the design works, not evidence this diff does.
- **Android is entirely compile-unverified**, and it is the larger half of the
  risk here: a new `TextInputProps` field, a slot builder using `IconButton` +
  `MaterialIcon`, and a `visualTransformation` overload. Please have someone
  with a Compose build run it before merging.
- **Layout impact when the toggle is on.** The iOS eye uses
  `.nuiMinTapTarget()` (the repo's 44×44 HIG helper), which will make a `md`
  field a few points taller than its 41pt content height. That is correct for
  a tappable control and only affects fields that opted in, but it is a real
  visual change I could not eyeball.
