### PR TITLE
fix: Android images default to Fit when no object-* class is set

### DIFF
--- a/resources/android/ImageRenderer.kt
+++ b/resources/android/ImageRenderer.kt
@@ -16,7 +16,11 @@ object ImageRenderer {
     fun Render(node: NativeUINode, modifier: Modifier) {
         val p = node.props
         val src = p.getString("src")
-        val fit = p.getInt("fit")
+        // No `fit` prop means no `object-*` class. Default to Fit (1) so
+        // an unclassed image scales into its frame like iOS does, instead
+        // of ContentScale.None painting the bitmap at intrinsic size and
+        // center-cropping it to the frame.
+        val fit = p.getInt("fit", 1)
         val alt = p.getString("alt")
         val tintArgb = p.getColor("tint_color", 0)
         val radius = node.style?.borderRadius ?: 0f


### PR DESCRIPTION
## Problem

`native:image` without an `object-*` class renders differently on each platform. The PHP `Image` element only emits `fit` when one is set, and the renderers disagree on the missing-prop default:

- iOS `resolveContentMode(0)` → `.fit`
- Android `p.getInt("fit")` → `0` → `ContentScale.None`

On Android the bitmap is painted at intrinsic size and center-cropped to the frame. A 1024×1024 logo in a `w-10 h-10` box shows only a 40 dp patch from its middle.

| iOS | Android |
|---|---|
| whole logo scaled into the frame | center crop of the source |

## Fix

`p.getInt("fit", 1)` — a missing prop now defaults to Fit, matching iOS. An explicit `object-none` still sends `fit: 0` and keeps `ContentScale.None`; the other mappings are unchanged.