### PR TITLE
Implement ScrollView::autoScrollTo() in both renderers

### DIFF
--- a/resources/android/ContainerRenderers.kt
+++ b/resources/android/ContainerRenderers.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -336,6 +337,57 @@ private fun totalDescendants(node: NativeUINode): Int {
     return count
 }
 
+/**
+ * Resolves `ScrollView::autoScrollTo($index)` into a concrete child index, or
+ * `-1` for "no target".
+ *
+ * The prop names a DIRECT child of the scroll view. An absent or negative
+ * value means the author isn't driving the scroll position at all.
+ *
+ * An index past the end is CLAMPED rather than dropped: PHP publishes the
+ * index and the children in the same frame, but a list that is still filling
+ * in (paginated history, a streamed response) can legitimately be shorter than
+ * the index for a frame or two. Clamping lands on the last child now and
+ * re-fires as the real target appears; dropping it would leave the list parked
+ * wherever it was.
+ */
+private fun resolveAutoScrollTarget(node: NativeUINode): Int {
+    val requested = node.props.getInt("auto_scroll_to", -1)
+    if (requested < 0 || node.children.isEmpty()) return -1
+
+    return requested.coerceAtMost(node.children.size - 1)
+}
+
+/**
+ * Drives a lazy list from the resolved `auto_scroll_to` target.
+ *
+ * Keyed on the RESOLVED index, so the scroll fires when the author's intent
+ * actually changes — not on every re-publish. A screen that re-renders for an
+ * unrelated reason (a tick, a toggle elsewhere) carries the same index and
+ * leaves a reader who has scrolled away exactly where they were. It also means
+ * a clamped target re-fires on its own once the list grows past it: the
+ * resolved value moves even though the prop didn't.
+ *
+ * First application jumps, later ones animate — matching `scroll-anchor`:
+ * a screen that opens already scrolled shouldn't visibly fly down from the
+ * top, but a later move is a state change the user should see happen.
+ */
+@Composable
+private fun AutoScrollToEffect(targetIndex: Int, listState: LazyListState) {
+    val didInitialScroll = remember { mutableStateOf(false) }
+
+    LaunchedEffect(targetIndex) {
+        if (targetIndex < 0) return@LaunchedEffect
+
+        if (!didInitialScroll.value) {
+            didInitialScroll.value = true
+            listState.scrollToItem(targetIndex)
+        } else {
+            listState.animateScrollToItem(targetIndex)
+        }
+    }
+}
+
 object ScrollViewRenderer {
     @Composable
     fun Render(node: NativeUINode, modifier: Modifier) {
@@ -345,8 +397,14 @@ object ScrollViewRenderer {
             detectVerticalDragGestures(onDragStart = { keyboardController?.hide() }) { _, _ -> }
         }
 
+        val autoScrollTarget = resolveAutoScrollTarget(node)
+
         if (horizontal) {
-            LazyRow(modifier = modifier) {
+            val rowState = rememberLazyListState()
+
+            AutoScrollToEffect(autoScrollTarget, rowState)
+
+            LazyRow(modifier = modifier, state = rowState) {
                 items(node.children, key = { it.id }) { child ->
                     NodeView(node = child)
                 }
@@ -360,7 +418,12 @@ object ScrollViewRenderer {
             // item with a max offset lands at the very bottom regardless of how
             // the content is nested. Hooks are called unconditionally to satisfy
             // Compose's rules; the work is gated on the prop.
-            val stickBottom = node.props.getString("scroll_anchor", "") == "bottom"
+            // An explicit `auto_scroll_to` wins over `scroll-anchor="bottom"`.
+            // Both drive the same LazyListState, so letting them run together
+            // would have two effects fighting over the same list — the author
+            // named a specific child, which is the more specific instruction.
+            val stickBottom = autoScrollTarget < 0 &&
+                node.props.getString("scroll_anchor", "") == "bottom"
             val listState = rememberLazyListState()
             val didInitialScroll = remember { mutableStateOf(false) }
             val contentSignal = if (stickBottom) totalDescendants(node) else 0
@@ -376,6 +439,8 @@ object ScrollViewRenderer {
                     }
                 }
             }
+
+            AutoScrollToEffect(autoScrollTarget, listState)
 
             // A `fill` / `h-full` DIRECT child asked to be at least as tall as
             // the VIEWPORT — the "short screen centred, still scrolls when the

--- a/resources/android/ContainerRenderers.kt
+++ b/resources/android/ContainerRenderers.kt
@@ -338,24 +338,35 @@ private fun totalDescendants(node: NativeUINode): Int {
 }
 
 /**
- * Resolves `ScrollView::autoScrollTo($index)` into a concrete child index, or
- * `-1` for "no target".
+ * The author's declared intent: the index passed to
+ * `ScrollView::autoScrollTo($index)`, or `-1` when they aren't driving the
+ * scroll position at all (prop absent, or negative).
  *
- * The prop names a DIRECT child of the scroll view. An absent or negative
- * value means the author isn't driving the scroll position at all.
+ * Deliberately independent of the children, so that precedence over
+ * `scroll-anchor` doesn't flicker while a list fills in.
+ */
+private fun autoScrollRequest(node: NativeUINode): Int {
+    val requested = node.props.getInt("auto_scroll_to", -1)
+
+    return if (requested < 0) -1 else requested
+}
+
+/**
+ * The child to actually bring into view, or `-1` when there is nothing to
+ * scroll to yet.
  *
- * An index past the end is CLAMPED rather than dropped: PHP publishes the
- * index and the children in the same frame, but a list that is still filling
- * in (paginated history, a streamed response) can legitimately be shorter than
- * the index for a frame or two. Clamping lands on the last child now and
- * re-fires as the real target appears; dropping it would leave the list parked
- * wherever it was.
+ * An index past the end is IGNORED, not clamped. Clamping looked like a
+ * kindness — land on the last child now, correct it later — but it ties the
+ * scroll to a row that moves whenever the CONTENT does rather than when the
+ * author's intent does. Removing rows then drags a reader down to the new end,
+ * and a list streaming in scrolls repeatedly on its way to a target it hasn't
+ * reached. Ignoring the index keeps the useful half: nothing happens until the
+ * named child exists, and then the list goes there exactly once.
  */
 private fun resolveAutoScrollTarget(node: NativeUINode): Int {
-    val requested = node.props.getInt("auto_scroll_to", -1)
-    if (requested < 0 || node.children.isEmpty()) return -1
+    val requested = autoScrollRequest(node)
 
-    return requested.coerceAtMost(node.children.size - 1)
+    return if (requested >= node.children.size) -1 else requested
 }
 
 /**
@@ -422,7 +433,14 @@ object ScrollViewRenderer {
             // Both drive the same LazyListState, so letting them run together
             // would have two effects fighting over the same list — the author
             // named a specific child, which is the more specific instruction.
-            val stickBottom = autoScrollTarget < 0 &&
+            //
+            // Gated on the REQUEST rather than the resolved target: an author
+            // who named a child owns the scroll position from that moment,
+            // including the frames before the child exists. Gating on the
+            // resolved target would hand control back to the anchor whenever
+            // the index is out of reach, so a list filling in would sit at the
+            // bottom and then jump.
+            val stickBottom = autoScrollRequest(node) < 0 &&
                 node.props.getString("scroll_anchor", "") == "bottom"
             val listState = rememberLazyListState()
             val didInitialScroll = remember { mutableStateOf(false) }

--- a/resources/ios/NativeUIScrollViewRenderer.swift
+++ b/resources/ios/NativeUIScrollViewRenderer.swift
@@ -26,7 +26,13 @@ struct NativeUIScrollViewRenderer: View {
         // Both drive the same ScrollViewReader, so letting them run together
         // would have two handlers fighting over the same list — the author
         // named a specific child, which is the more specific instruction.
-        let stickBottom = autoScrollIndex == nil
+        //
+        // Gated on the REQUEST rather than the resolved target: an author who
+        // named a child owns the scroll position from that moment, including
+        // the frames before the child exists. Gating on the resolved target
+        // would hand control back to the anchor whenever the index is out of
+        // reach, so a list filling in would sit at the bottom and then jump.
+        let stickBottom = autoScrollRequest == nil
             && node.props.getString("scroll_anchor", default: "") == "bottom"
         let messageSignal = stickBottom ? Self.descendantCount(node) : 0
 
@@ -82,7 +88,7 @@ struct NativeUIScrollViewRenderer: View {
                 // the left edge — the same place Android's `scrollToItem`
                 // puts it.
                 .onAppear { applyAutoScroll(proxy: proxy, anchor: .leading, animated: false) }
-                .onChange(of: autoScrollIndex) { _ in
+                .onChange(of: autoScrollIndex) { _, _ in
                     applyAutoScroll(proxy: proxy, anchor: .leading, animated: true)
                 }
             }
@@ -212,7 +218,7 @@ struct NativeUIScrollViewRenderer: View {
             // matching Android's `scrollToItem`, which puts the item at the
             // start of the list.
             .onAppear { applyAutoScroll(proxy: proxy, anchor: .top, animated: false) }
-            .onChange(of: autoScrollIndex) { _ in
+            .onChange(of: autoScrollIndex) { _, _ in
                 applyAutoScroll(proxy: proxy, anchor: .top, animated: true)
             }
             // The keyboard resizes the scroll viewport in BOTH directions —
@@ -246,29 +252,40 @@ struct NativeUIScrollViewRenderer: View {
         }
     }
 
-    /// Resolves `ScrollView::autoScrollTo($index)` into a concrete child
-    /// index, or `nil` for "no target".
+    /// The author's declared intent: the index passed to
+    /// `ScrollView::autoScrollTo($index)`, or `nil` when they aren't driving
+    /// the scroll position at all (prop absent, or negative).
     ///
-    /// The prop names a DIRECT child of the scroll view. An absent or negative
-    /// value means the author isn't driving the scroll position at all.
+    /// Deliberately independent of the children, so that precedence over
+    /// `scroll-anchor` doesn't flicker while a list fills in.
+    private var autoScrollRequest: Int? {
+        let requested = node.props.getInt("auto_scroll_to", default: -1)
+
+        return requested >= 0 ? requested : nil
+    }
+
+    /// The child to actually bring into view, or `nil` when there is nothing
+    /// to scroll to yet.
     ///
-    /// An index past the end is CLAMPED rather than dropped: PHP publishes the
-    /// index and the children in the same frame, but a list that is still
-    /// filling in (paginated history, a streamed response) can legitimately be
-    /// shorter than the index for a frame or two. Clamping lands on the last
-    /// child now and re-fires as the real target appears; dropping it would
-    /// leave the list parked wherever it was.
+    /// An index past the end is IGNORED, not clamped. Clamping looked like a
+    /// kindness — land on the last child now, correct it later — but it ties
+    /// the scroll to a row that moves whenever the CONTENT does rather than
+    /// when the author's intent does. Removing rows then drags a reader down
+    /// to the new end, and a list streaming in scrolls repeatedly on its way
+    /// to a target it hasn't reached. Ignoring the index keeps the useful
+    /// half: nothing happens until the named child exists, and then the list
+    /// goes there exactly once.
     ///
-    /// Driving `.onChange` off the RESOLVED index (rather than the raw prop)
+    /// Driving `.onChange` off this RESOLVED value (rather than the raw prop)
     /// is what keeps a re-publish from yanking the reader: a screen that
     /// re-renders for an unrelated reason carries the same index and nothing
-    /// fires. It also makes a clamped target re-fire on its own once the list
-    /// grows past it — the resolved value moves even though the prop didn't.
+    /// fires.
     private var autoScrollIndex: Int? {
-        let requested = node.props.getInt("auto_scroll_to", default: -1)
-        guard requested >= 0, !node.children.isEmpty else { return nil }
+        guard let requested = autoScrollRequest,
+              requested < node.children.count
+        else { return nil }
 
-        return min(requested, node.children.count - 1)
+        return requested
     }
 
     /// Brings the `auto_scroll_to` child into view.

--- a/resources/ios/NativeUIScrollViewRenderer.swift
+++ b/resources/ios/NativeUIScrollViewRenderer.swift
@@ -11,12 +11,23 @@ struct NativeUIScrollViewRenderer: View {
     /// bottom-anchored list opens at the bottom.
     @State private var atBottom: Bool = true
 
+    /// Whether `auto_scroll_to` has been applied once already. The first
+    /// application jumps (a screen that opens already scrolled shouldn't fly
+    /// down from the top); later ones animate, so a move the user didn't
+    /// initiate is visible rather than teleporting the content.
+    @State private var didInitialAutoScroll: Bool = false
+
     var body: some View {
         let horizontal = node.props.getBool("horizontal")
         let showsIndicators = node.props.getBool("shows_indicators", default: true)
         let spacing = CGFloat(node.layout?.gap ?? 0)
         let axis = node.props.getString("axis", default: "")
-        let stickBottom = node.props.getString("scroll_anchor", default: "") == "bottom"
+        // An explicit `auto_scroll_to` wins over `scroll-anchor="bottom"`.
+        // Both drive the same ScrollViewReader, so letting them run together
+        // would have two handlers fighting over the same list — the author
+        // named a specific child, which is the more specific instruction.
+        let stickBottom = autoScrollIndex == nil
+            && node.props.getString("scroll_anchor", default: "") == "bottom"
         let messageSignal = stickBottom ? Self.descendantCount(node) : 0
 
         // 2D mode. Bypass the Lazy stacks (which force 1D layout) and use a
@@ -33,6 +44,10 @@ struct NativeUIScrollViewRenderer: View {
             // content view directly inside the ScrollView so the content's
             // own `.frame(...)` (set by NodeLayoutModifier from `w-[N]` /
             // `h-[N]` classes) drives the scrollable size.
+            //
+            // `auto_scroll_to` is deliberately not honoured here: children in
+            // 2D mode are layered at their own frames rather than sequenced,
+            // so "the child at index N" has no position to scroll to.
             //
             // Multi-child 2D scrolls are rare (typical use is one large
             // image / canvas). For multiple children we layer them in a
@@ -53,15 +68,24 @@ struct NativeUIScrollViewRenderer: View {
             }
             .scrollDismissesKeyboard(.interactively)
         } else if horizontal {
-            ScrollView(.horizontal, showsIndicators: showsIndicators) {
-                LazyHStack(alignment: .top, spacing: spacing) {
-                    ForEach(node.children) { child in
-                        NodeView(node: child)
-                            .equatable()
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal, showsIndicators: showsIndicators) {
+                    LazyHStack(alignment: .top, spacing: spacing) {
+                        ForEach(node.children) { child in
+                            NodeView(node: child)
+                                .equatable()
+                        }
                     }
                 }
+                .scrollDismissesKeyboard(.interactively)
+                // `.leading`, so a horizontal auto-scroll parks the target at
+                // the left edge — the same place Android's `scrollToItem`
+                // puts it.
+                .onAppear { applyAutoScroll(proxy: proxy, anchor: .leading, animated: false) }
+                .onChange(of: autoScrollIndex) { _ in
+                    applyAutoScroll(proxy: proxy, anchor: .leading, animated: true)
+                }
             }
-            .scrollDismissesKeyboard(.interactively)
         } else if hasFillHeightChild {
             // A `fill` / `h-full` child asked to be at least as tall as the
             // VIEWPORT — the "short screen centred, still scrolls when the
@@ -184,6 +208,13 @@ struct NativeUIScrollViewRenderer: View {
                     proxy.scrollTo(Self.bottomAnchorID, anchor: .bottom)
                 }
             }
+            // `.top`, so the named child parks at the top of the viewport —
+            // matching Android's `scrollToItem`, which puts the item at the
+            // start of the list.
+            .onAppear { applyAutoScroll(proxy: proxy, anchor: .top, animated: false) }
+            .onChange(of: autoScrollIndex) { _ in
+                applyAutoScroll(proxy: proxy, anchor: .top, animated: true)
+            }
             // The keyboard resizes the scroll viewport in BOTH directions —
             // it shrinks on the way in (the screen shifts up for keyboard
             // avoidance) and grows back on the way out. Re-pin on each, so
@@ -211,6 +242,61 @@ struct NativeUIScrollViewRenderer: View {
                 // straight back down and undo the scroll that dismissed it.
                 guard atBottom else { return }
                 repinToBottom(stickBottom: stickBottom, proxy: proxy, note: note)
+            }
+        }
+    }
+
+    /// Resolves `ScrollView::autoScrollTo($index)` into a concrete child
+    /// index, or `nil` for "no target".
+    ///
+    /// The prop names a DIRECT child of the scroll view. An absent or negative
+    /// value means the author isn't driving the scroll position at all.
+    ///
+    /// An index past the end is CLAMPED rather than dropped: PHP publishes the
+    /// index and the children in the same frame, but a list that is still
+    /// filling in (paginated history, a streamed response) can legitimately be
+    /// shorter than the index for a frame or two. Clamping lands on the last
+    /// child now and re-fires as the real target appears; dropping it would
+    /// leave the list parked wherever it was.
+    ///
+    /// Driving `.onChange` off the RESOLVED index (rather than the raw prop)
+    /// is what keeps a re-publish from yanking the reader: a screen that
+    /// re-renders for an unrelated reason carries the same index and nothing
+    /// fires. It also makes a clamped target re-fire on its own once the list
+    /// grows past it — the resolved value moves even though the prop didn't.
+    private var autoScrollIndex: Int? {
+        let requested = node.props.getInt("auto_scroll_to", default: -1)
+        guard requested >= 0, !node.children.isEmpty else { return nil }
+
+        return min(requested, node.children.count - 1)
+    }
+
+    /// Brings the `auto_scroll_to` child into view.
+    ///
+    /// Targets the child's node id, which is the identity `ForEach` already
+    /// assigns to each row (`NativeUINode: Identifiable`), so no extra `.id()`
+    /// is needed on the row's modifier chain.
+    ///
+    /// `animated` is decided by the caller's context, but the FIRST successful
+    /// application always jumps regardless — an `.onChange` can be the first
+    /// thing to fire when the prop arrives after the initial layout.
+    private func applyAutoScroll(proxy: ScrollViewProxy, anchor: UnitPoint, animated: Bool) {
+        guard let index = autoScrollIndex else { return }
+
+        let targetID = node.children[index].id
+        let shouldAnimate = animated && didInitialAutoScroll
+        didInitialAutoScroll = true
+
+        // Defer past first layout — lazy content isn't measured yet inside
+        // `onAppear`, so an immediate `scrollTo` no-ops. Same reason the
+        // bottom-anchor pin defers.
+        DispatchQueue.main.async {
+            if shouldAnimate {
+                withAnimation(.easeOut(duration: 0.25)) {
+                    proxy.scrollTo(targetID, anchor: anchor)
+                }
+            } else {
+                proxy.scrollTo(targetID, anchor: anchor)
             }
         }
     }


### PR DESCRIPTION
Fixes the dead API reported in NativePHP/mobile-air#366.

> Reviewed on device by @gwleuverink, who found two real bugs (a one-behind `.onChange` on iOS, and clamping dragging the reader around on content changes). Both are fixed — see the [review reply](https://github.com/NativePHP/mobile-ui/pull/67#issuecomment-5552811475) for the reasoning and for two open design questions.

## The problem

`ScrollView::autoScrollTo($index)` builds a prop, the prop crosses the wire intact, and then nothing reads it. Confirmed end to end:

```
ScrollView::make(...)->autoScrollTo(1)->toArray(...)
  => type: scroll_view
     props: {"auto_scroll_to":1}
```

`auto_scroll_to` appears **zero times** in this repo — neither `NativeUIScrollViewRenderer.swift` nor `ScrollViewRenderer` in `ContainerRenderers.kt` looks at it. `scroll_anchor` right next to it is read on both platforms; this one was just never wired up. The docs describe it, and mobile-air's own `BenchmarkComponent` drives its "Large List 10k FPS" scenario with it — so that benchmark has been measuring a list that never moves.

## The fix

Read the prop on both platforms and drive the list from it. Semantics are matched across iOS and Android:

| Behaviour | Rule |
|---|---|
| Meaning of the index | A **direct child**, as documented |
| Absent / negative | No target — the author isn't driving scroll position |
| Index past the end | **Ignored** — nothing happens until the child exists |
| When it fires | When the **resolved** target changes — not on every publish |
| First vs. later | First application jumps, later ones animate (same rule `scroll-anchor` follows) |
| vs. `scroll-anchor="bottom"` | An explicit `auto_scroll_to` **request** wins |
| Resting position | Start of the viewport (`.top` / `.leading`, matching Compose's `scrollToItem`) |

Three choices worth calling out:

**An out-of-range index is ignored, not clamped.** Clamping to the last child looks like a kindness, but it ties the scroll to a row that moves whenever the *content* does rather than when the author's intent does. On device that meant removing rows dragged the reader down to the new end, and a list streaming in scrolled repeatedly on its way to a target it hadn't reached yet. Ignoring keeps the useful half: nothing happens until the named child exists, then the list goes there once.

**Precedence keys on the request, not the resolved target.** These are deliberately two ideas — `autoScrollRequest` (did the author name a child at all? content-independent) and `autoScrollIndex` (does it exist yet? drives the scroll). `scroll-anchor="bottom"` loses to the *request*, so an author who sets both gets a list that stays put until the row exists and then goes to it, rather than sitting at the bottom and jumping once it appears.

**The effect keys on the resolved target.** That's what stops a re-publish from yanking the reader: a screen that re-renders for an unrelated reason carries the same index and nothing fires.

Horizontal scroll views are covered too — the iOS one gains a `ScrollViewReader` and the Android `LazyRow` an explicit list state, neither of which it had.

`axis="both"` is skipped **on iOS**, where children are layered at their own frames rather than sequenced, so an index has no position to scroll to. Android has no 2D path to skip: it never reads `axis`, and `both()` sets only `axis` and never `horizontal`, so such a view already falls through to the vertical list and auto-scroll applies to it. That Android gap predates this PR and wants its own issue rather than a guard here.

## Testing

Everything below ran in Docker.

**Repo CI, at parity** — `pest` (217 passed, 735 assertions), `pint --test` (104 files), `php -l` over `src/` (86 files), `swiftc -parse` over all 46 `resources/ios/*.swift`.

**The resolution logic, executed.** Both resolvers are extracted *verbatim from the committed files* into standalone programs and run, so the shipped expressions are what get exercised. iOS and Android are given the same truth table — in range, boundary, one-past-end, far-past-end, negative, empty children, single child, and the benchmark's own 1-child/index-9999 shape — and **agree on every case**. A second table checks that the *request* stays content-independent, which is what makes `scroll-anchor` precedence stable.

**Publish-sequence tests**, replaying realistic frame sequences through the real resolver and counting the scrolls the list would perform:

```
same index republished 5x            -> [7]        one scroll, reader not yanked
index changes 0,0,4,4,9              -> [0, 4, 9]  one per distinct target
fixed target 2, list grows 10->12    -> [2]        content churn doesn't drag the user
target removed mid-sequence          -> [3, 3]     control handed back and retaken
no prop across publishes             -> []
```

Including regressions for both bugs found on device:

```
removal: target 25, list 30 -> 20    -> [25]       was [25, 19]        (the drag)
growth:  target 20, list 5,10,15,21  -> [20]       was [4,9,14,20]     (the stutter)
```

And one that documents a known gap rather than asserting good behaviour — a search screen holding `autoScrollTo(0)` across new result sets fires only once, because 0 → 0 isn't a change. That needs an author-supplied re-arm token, which needs a builder argument that doesn't exist yet; discussed in the review thread.

**Kotlin type-check against real Compose.** The new functions plus the exact call-site wiring compile against real `androidx.compose.*` artifacts (Compose Multiplatform 1.7.3 + Compose compiler plugin, Kotlin 2.1.0) with zero errors and zero warnings from frontend analysis.

**Negative controls**, because a green check that can't fail proves nothing: injected bugs are each caught — wrong import, wrong argument type, wrong parameter name, suspend call outside a coroutine — and mutating the clamp or the negative guard produces failing assertions rather than silence.

**What I could not test: on-device behaviour.** No simulator or emulator here. @gwleuverink covered this round on an iPhone 17 Pro simulator and an API 36 emulator, which is how both bugs surfaced — notably, `swiftc -parse` performs no semantic analysis and so emits no deprecation diagnostics, and a pure-logic test can't reach SwiftUI's event wiring. Another pass would be welcome on the changed paths.

## Not included

Two follow-ups belong in mobile-air, not here:

1. There is no `auto-scroll-to` Blade attribute, so `<native:scroll-view>` still can't express this — only the PHP builder can. `scroll-anchor` is mapped in `NativeElementCollector`; this isn't.
2. `BenchmarkComponent::renderLargeListFpsScreen()` calls `autoScrollTo($itemCount - 1)` on a scroll view whose only direct child is a wrapping `Column`. Index 9999 against one child now resolves to nothing at all, so **that benchmark scenario still does not scroll and this PR does not fix it** — it needs restructuring so the rows are direct children.

Related: #27 implements this alongside the Android `gap` fix and chrome-collapse work, and is blocked on NativePHP/mobile-air#241. This PR is the isolated `auto_scroll_to` piece; happy to defer to #27 or have it drop that section, whichever the maintainers prefer.
