### PR TITLE
fix: only attach iOS pull-to-refresh when the list declares on-refresh

### DIFF
--- a/resources/ios/NativeUIListRenderer.swift
+++ b/resources/ios/NativeUIListRenderer.swift
@@ -91,12 +91,12 @@ struct NativeUIListRenderer: View {
             // the supported route (iOS 16+).
             .scrollIndicators(showsIndicators ? .automatic : .hidden)
             .scrollDismissesKeyboard(.interactively)
-            .refreshable {
-                if onRefreshCb != 0 {
-                    NativeElementBridge.sendPressEvent(onRefreshCb, nodeId: nodeId)
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
-                }
-            }
+            // Attach the refresh control only when the list declares an
+            // on-refresh handler — an unconditional .refreshable installs
+            // pull-to-refresh (spinner and all) on every list, including
+            // static settings/forms where it does nothing. Android's renderer
+            // already gates its PullToRefreshBox the same way.
+            .modifier(ListRefreshModifier(onRefreshCb: onRefreshCb, nodeId: nodeId))
         }
     }
 
@@ -229,6 +229,24 @@ private struct ListBackgroundModifier: ViewModifier {
             content
                 .scrollContentBackground(.hidden)
                 .background(Color(argb: argb))
+        } else {
+            content
+        }
+    }
+}
+
+/// Conditionally attaches pull-to-refresh: only lists with an `on_refresh`
+/// callback get the control; every other list scrolls plainly.
+private struct ListRefreshModifier: ViewModifier {
+    let onRefreshCb: Int
+    let nodeId: Int
+
+    func body(content: Content) -> some View {
+        if onRefreshCb != 0 {
+            content.refreshable {
+                NativeElementBridge.sendPressEvent(onRefreshCb, nodeId: nodeId)
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
         } else {
             content
         }


### PR DESCRIPTION
## The bug

Every `native:list` on iOS offers pull-to-refresh — including static settings screens and forms. Pull down and a spinner appears, spins, and does nothing.

## Why

The renderer applies `.refreshable` unconditionally; the `on_refresh` check lives *inside* the closure:

```swift
.refreshable {
    if onRefreshCb != 0 { ... }
}
```

That guards the callback, but SwiftUI installs the refresh control (spinner included) the moment `.refreshable` is attached — whether or not the closure does anything. The Android renderer already gates its whole `PullToRefreshBox` on `onRefreshCb != 0`, so the two platforms disagree.

## The fix

Move the check outside: a conditional modifier attaches `.refreshable` only when the list declares an `on-refresh` handler. Lists without one scroll plainly, matching Android and the dedicated `native:refreshable` element's opt-in contract. Behavior with a handler is unchanged.
