### PR TITLE
fix(iOS): load leading images from plain file paths on iOS list items

### DIFF
--- a/resources/ios/NativeUIListItemRenderer.swift
+++ b/resources/ios/NativeUIListItemRenderer.swift
@@ -142,10 +142,16 @@ struct NativeUIListItemRenderer: View {
             }
         case "avatar":
             // Decorative — the row's text content carries the meaning.
-            AsyncImage(url: URL(string: value)) { image in
-                image.resizable().scaledToFill()
-            } placeholder: {
-                Circle().fill(Color(.systemGray5))
+            Group {
+                if let path = NativeUILocalImage.path(for: value) {
+                    leadingLocalImage(path: path) { Circle().fill(Color(.systemGray5)) }
+                } else {
+                    AsyncImage(url: URL(string: value)) { image in
+                        image.resizable().scaledToFill()
+                    } placeholder: {
+                        Circle().fill(Color(.systemGray5))
+                    }
+                }
             }
             .frame(width: 40, height: 40)
             .clipShape(Circle())
@@ -163,10 +169,18 @@ struct NativeUIListItemRenderer: View {
             .accessibilityHidden(true)
         case "image":
             // Decorative — the row's text content carries the meaning.
-            AsyncImage(url: URL(string: value)) { image in
-                image.resizable().scaledToFill()
-            } placeholder: {
-                RoundedRectangle(cornerRadius: 4).fill(Color(.systemGray5))
+            Group {
+                if let path = NativeUILocalImage.path(for: value) {
+                    leadingLocalImage(path: path) {
+                        RoundedRectangle(cornerRadius: 4).fill(Color(.systemGray5))
+                    }
+                } else {
+                    AsyncImage(url: URL(string: value)) { image in
+                        image.resizable().scaledToFill()
+                    } placeholder: {
+                        RoundedRectangle(cornerRadius: 4).fill(Color(.systemGray5))
+                    }
+                }
             }
             .frame(width: 56, height: 56)
             .clipShape(RoundedRectangle(cornerRadius: 4))
@@ -217,6 +231,21 @@ struct NativeUIListItemRenderer: View {
         } else {
             tinted
                 .accessibilityValue(a11yValue)
+        }
+    }
+
+    /// Decode a file on disk for a leading slot. `AsyncImage` only speaks
+    /// http(s), so a `file://` URL or an absolute path has to be read
+    /// directly — the same route `NativeUIImageRenderer` takes.
+    @ViewBuilder
+    private func leadingLocalImage<Placeholder: View>(
+        path: String,
+        @ViewBuilder placeholder: () -> Placeholder
+    ) -> some View {
+        if let uiImage = UIImage(contentsOfFile: path) {
+            Image(uiImage: uiImage).resizable().scaledToFill()
+        } else {
+            placeholder()
         }
     }
 

--- a/resources/ios/NativeUILocalImage.swift
+++ b/resources/ios/NativeUILocalImage.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Shared resolver for image sources that point at a file on the device
+/// rather than a remote URL.
+///
+/// `AsyncImage` / `URLSession` cannot load `file://` URLs or bare filesystem
+/// paths, so every renderer that accepts an image source has to decide
+/// between decoding with `UIImage(contentsOfFile:)` and going through the
+/// async loader. The `<image>` element and a list row's leading slots all
+/// need that decision, so it lives here instead of being duplicated.
+enum NativeUILocalImage {
+    /// The local filesystem path for `src` (a `file://…` URL or an absolute
+    /// `/…` path), or nil when `src` is a remote URL that should go through
+    /// `AsyncImage`.
+    static func path(for src: String) -> String? {
+        if src.hasPrefix("file://") {
+            return URL(string: src)?.path ?? String(src.dropFirst("file://".count))
+        }
+        if src.hasPrefix("/") {
+            return src
+        }
+        return nil
+    }
+}

--- a/resources/ios/NativeUISimpleRenderers.swift
+++ b/resources/ios/NativeUISimpleRenderers.swift
@@ -229,17 +229,8 @@ struct NativeUIImageRenderer: View {
         }
     }
 
-    /// Resolves `src` to a local filesystem path when it points at an
-    /// on-device file (`file://…` URL or an absolute `/…` path), or nil
-    /// when it's a remote URL that should go through AsyncImage.
     private static func localFilePath(for src: String) -> String? {
-        if src.hasPrefix("file://") {
-            return URL(string: src)?.path ?? String(src.dropFirst("file://".count))
-        }
-        if src.hasPrefix("/") {
-            return src
-        }
-        return nil
+        NativeUILocalImage.path(for: src)
     }
 
     private func resolveContentMode(_ fit: Int) -> ContentMode {


### PR DESCRIPTION
## The bug

Give a list item a leading image that lives on the device:

```blade
<native:list-item headline="Yaniv" leadingImage="{{ public_path('yaniv-art.png') }}" />
```

On Android you get the image. On iOS you get a grey placeholder, forever. `file://` and `https://` sources are
fine — it's the plain path that dead-ends.

That's the shape most PHP sources have: `public_path()`, `storage_path()`, and the paths the camera and file
pickers hand back. `<native:image>` already accepts them, so today the same string renders in one element and
silently fails in the other.

## Why

Both leading slots resolve their source through `AsyncImage` alone:

```swift
AsyncImage(url: URL(string: value)) { … }
```

`URL(string: "/var/…/photo.png")` has no scheme, so URLSession has nothing to fetch and the placeholder never
goes away.

## The fix

Decode local sources with `UIImage(contentsOfFile:)` — exactly what `NativeUIImageRenderer` already does — and
keep `AsyncImage` for remote URLs. Applied to both the `image` and `avatar` slots, since an avatar is just as
likely to be a file the app just saved.

The "is this local?" check moves into a shared `NativeUILocalImage`, so the two renderers can't drift on the
answer.

iOS only — Android's Coil takes a path as-is. No PHP or wire changes, and nothing that renders today changes:
only sources that showed a placeholder start showing an image.

## Before / after (iPhone 17 simulator, iOS 26, same Blade)

<img src="https://raw.githubusercontent.com/SRWieZ/mobile-ui/18f667903b04c963fdbf7b06cb8b3efb7c0fd9d6/pair.png" width="900">
