### PR TITLE
fix: Android bare text input ignores keyboard="number" (and every keyboard type)

### DIFF
--- a/resources/android/BareTextInputRenderer.kt
+++ b/resources/android/BareTextInputRenderer.kt
@@ -156,6 +156,11 @@ object BareTextInputRenderer {
                 }
                 innerTextField()
             },
+            // Filled and Outlined pass this since day one; Bare never did, so
+            // `keyboard="number"` (and the derived capitalization) were
+            // silently ignored on bare inputs — the plain text keyboard
+            // always came up.
+            keyboardOptions = keyboardOptionsFor(props),
             keyboardActions = KeyboardActions(onAny = {
                 // Flush the settled caret before the submit event fires.
                 selectionReporter.flush(value)


### PR DESCRIPTION
## What's wrong
**`keyboard="number"` on `<native:bare-text-input>` shows the full text keyboard on Android.** The filled and outlined renderers pass `keyboardOptions` to their text field; the bare renderer never did — so the keyboard type (and the capitalization derived from it, and the IME action face) were silently dropped.

Minimum repro:

```blade
<native:bare-text-input native:model="amount" keyboard="number" placeholder="Amount" class="flex-1" />
```

## What this does
One line — pass `keyboardOptionsFor(props)` to the bare input's `BasicTextField`, same as the other two variants. No iOS or PHP changes.

## Before / after (Android emulator, API 36, same Blade)
<img src="https://raw.githubusercontent.com/SRWieZ/mobile-ui/51558bef72e616e145b64f790753044a03a968a8/pair-keyboard.png" width="900">
