### PR TITLE
fix: Android progress bars show a stray dot at the end

### DIFF
--- a/resources/android/ProgressBarRenderer.kt
+++ b/resources/android/ProgressBarRenderer.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import com.nativephp.mobile.ui.nativerender.NativeUINode
@@ -38,11 +39,19 @@ object ProgressBarRenderer {
                 trackColor = track,
             )
         } else {
+            // Determinate bars drop M3 1.7's expressive extras — the stop
+            // indicator dot at the track's end and the gap between progress
+            // tip and track. On the thin bars this element renders they read
+            // as stray dots at both edges (a near-empty bar shows exactly
+            // two dots and nothing else), and the iOS renderer's ProgressView
+            // draws a plain continuous bar — parity wins.
             LinearProgressIndicator(
                 progress = { p.getFloat("value").coerceIn(0f, 1f) },
                 modifier = barModifier,
                 color = tint,
                 trackColor = track,
+                gapSize = 0.dp,
+                drawStopIndicator = {},
             )
         }
     }


### PR DESCRIPTION
## What's wrong
**A thin determinate `<native:progress-bar>` on Android shows a stray dot at its right end.** Material3 1.7's `LinearProgressIndicator` draws an "expressive" stop-indicator dot at the track's end plus a gap between the progress tip and the track — on a thin bar a near-empty value reads as two floating dots and not much else. iOS draws a plain continuous bar.

Minimum repro:

```blade
<native:progress-bar :value="0.06" class="w-full" />
<native:progress-bar :value="0.45" class="w-full" />
<native:progress-bar :value="0.9" class="w-full" />
```

## What this does
Determinate bars pass `gapSize = 0.dp` and an empty `drawStopIndicator` — a plain continuous bar, matching iOS. Indeterminate bars keep the animated M3 style. *Judgment call:* if you'd rather keep the M3 expressive look as the Android default, say the word and I'll flip this to an opt-in prop instead. No iOS or PHP changes.

## Before / after (Android emulator, API 36, same Blade)
<img src="https://raw.githubusercontent.com/SRWieZ/mobile-ui/51558bef72e616e145b64f790753044a03a968a8/pair-progress.png" width="900">
