### PR TITLE
fix(ios): clear the List row fill so a declared list background shows

### DIFF
--- a/resources/ios/NativeUIListRenderer.swift
+++ b/resources/ios/NativeUIListRenderer.swift
@@ -114,6 +114,11 @@ struct NativeUIListRenderer: View {
             .equatable()
             .frame(maxWidth: .infinity, alignment: .leading)
             .listRowInsets(EdgeInsets())
+            // Rows carry SwiftUI's opaque system fill, which paints over the
+            // list's own background — so hiding the scroll background via
+            // ListBackgroundModifier still left a white sheet on a themed
+            // screen. Clear the row and let its content decide.
+            .listRowBackground(Color.clear)
             // Drive dividers from the bottom edge only; always hide the top
             // edge. The top separator renders solely on a section's first row,
             // so hiding it removes the stray full-width line that otherwise


### PR DESCRIPTION
## The bug

`ListBackgroundModifier` hides the grouped scroll background when a list node declares one:

```swift
content
    .scrollContentBackground(.hidden)
    .background(Color(argb: argb))
```

But SwiftUI also gives **every row** an opaque system fill, and that paints over the list's background. So `<list class="bg-theme-background">` still renders as a white sheet, with the declared colour visible only in the thin strips above the first row and below the last.

The effect is that a themed list-based screen looks broken next to an otherwise-identical scroll-view-based one.

## The fix

One line in `rowView()`:

```swift
.listRowBackground(Color.clear)
```

The row becomes transparent, so the list's declared background shows through, and each row still paints whatever its own content declares (a card, a surface colour, nothing).

## Scope

- Only affects lists that **declare a background** — `ListBackgroundModifier` is already a no-op otherwise, so the stock grouped look is unchanged for everyone else.
- **Android is unaffected**: Compose has no implicit row fill, and `ListRenderer.kt` already draws `MaterialTheme.colorScheme.background`.

## Verified

Built and run on an iOS 26 simulator against a themed app: a `<list>` screen now matches its `<scroll-view>` equivalent, rows still render their own card backgrounds, and separators/swipe actions are unchanged.