### PR TITLE
fix(ios): theme the drawer panel and inset it below the status bar

### DIFF
--- a/resources/ios/NativeUIDrawerHost.swift
+++ b/resources/ios/NativeUIDrawerHost.swift
@@ -65,6 +65,7 @@ struct NativeDrawerHost<Content: View>: View {
 
     @ObservedObject private var state = DrawerHostState.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.nativeUITheme) private var theme
     @State private var dragOffset: CGFloat = 0
 
     private let edgeSwipeThreshold: CGFloat = 30
@@ -223,10 +224,21 @@ struct NativeDrawerHost<Content: View>: View {
                     NodeView(node: child).equatable()
                 }
             }
+            // The panel ignores the safe area so its background reaches the top
+            // of the screen; without this inset the CONTENT does too, and the
+            // first row slides under the status bar. An app that pins
+            // UIUserInterfaceStyle sees this at every launch, not just on a
+            // notched device in landscape.
+            .padding(.top, windowSafeAreaTop)
         }
         .frame(width: width)
         .frame(maxHeight: .infinity)
-        .background(Color(.systemBackground))
+        // The THEME background, not Color(.systemBackground). The drawer's own
+        // content paints only as tall as it is, so everything below the last
+        // row fell through to the system colour — white on a light-pinned app,
+        // regardless of the site's palette. A themed panel that turns white
+        // halfway down reads as a rendering fault, because it is one.
+        .background(theme.background)
     }
 
     // MARK: - Gesture settling


### PR DESCRIPTION
Two defects visible the moment a drawer opens on a themed app.

### The panel is not themed

`drawerView` paints `Color(.systemBackground)`. The drawer's content is only as tall as it is, so everything below the last row falls through to the system colour — white on an app that pins `UIUserInterfaceStyle`, whatever the theme says.

A themed panel that turns white halfway down reads as a rendering fault, because it is one. It now paints `theme.background`, read from `\.nativeUITheme` like every other renderer.

### The content ignores the safe area along with the background

The panel deliberately ignores the safe area so its background can reach the top of the screen. The **content** ignores it too, so the first row slides under the status bar — on a white-label app this put the site name directly over the clock.

The content is now padded by the window's top inset, reusing the `windowSafeAreaTop` this file already computes for the ☰ button, and for the same stated reason: a nested `GeometryReader` reports an unreliable `safeAreaInsets.top` here.

### Note for consumers

A drawer view that declares its own `safe-area` (or its own scroll view) should drop it — the host provides both, and declaring them again double-counts the inset and nests a scroll view inside a scroll view.

Reported against a white-label app whose drawer showed the site name overlapping the status bar with the lower half of the panel rendering white.