### PR TITLE
fix: let a chip's @press handler actually fire

### DIFF
--- a/resources/android/ChipRenderer.kt
+++ b/resources/android/ChipRenderer.kt
@@ -31,6 +31,7 @@ object ChipRenderer {
         val label       = p.getString("label")
         val iconName    = p.getString("icon")
         val onChangeCb  = p.getCallbackId("on_change")
+        val onPressCb   = p.getCallbackId("on_press").let { if (it != 0) it else node.onPress }
         val disabled    = p.getBool("disabled")
         val a11yLabel   = p.getString("a11y_label")
         val a11yHint    = p.getString("a11y_hint")
@@ -68,11 +69,18 @@ object ChipRenderer {
         FilterChip(
             selected = isSelected,
             onClick = {
-                val new = !isSelected
-                isSelected = new
-                lastSentValue = new
-                if (onChangeCb != 0) {
-                    NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
+                if (onPressCb != 0) {
+                    // Server-driven: the press handler owns selection. Toggling
+                    // locally would make the chip fight the state it is handed
+                    // back, so a filter chip would flicker off on its own tap.
+                    NativeUIBridge.sendPressEvent(onPressCb, node.id)
+                } else {
+                    val new = !isSelected
+                    isSelected = new
+                    lastSentValue = new
+                    if (onChangeCb != 0) {
+                        NativeUIBridge.sendToggleChangeEvent(onChangeCb, node.id, new)
+                    }
                 }
             },
             label = { Text(label, fontFamily = nuiDefaultFontFamily()) },

--- a/resources/ios/NativeUIChipRenderer.swift
+++ b/resources/ios/NativeUIChipRenderer.swift
@@ -29,6 +29,7 @@ struct NativeUIChipRenderer: View {
         let label       = p.getString("label")
         let iconName    = p.getString("icon")
         let onChangeCb  = p.getCallbackId("on_change")
+        let onPressCb   = p.getCallbackId("on_press") != 0 ? p.getCallbackId("on_press") : node.onPress
         let disabled    = p.getBool("disabled")
         let a11yLabel   = p.getString("a11y_label")
         let a11yHint    = p.getString("a11y_hint")
@@ -45,11 +46,18 @@ struct NativeUIChipRenderer: View {
 
         Button(action: {
             guard !disabled else { return }
-            let new = !isSelected
-            isSelected = new
-            lastSentValue = new
-            if onChangeCb != 0 {
-                NativeElementBridge.sendToggleChangeEvent(onChangeCb, nodeId: node.id, value: new)
+            if onPressCb != 0 {
+                // Server-driven: the press handler owns selection. Toggling
+                // locally would make the chip fight the state it is handed
+                // back, so a filter chip would flicker off on its own tap.
+                NativeElementBridge.sendPressEvent(onPressCb, nodeId: node.id)
+            } else {
+                let new = !isSelected
+                isSelected = new
+                lastSentValue = new
+                if onChangeCb != 0 {
+                    NativeElementBridge.sendToggleChangeEvent(onChangeCb, nodeId: node.id, value: new)
+                }
             }
         }) {
             HStack(spacing: 6) {


### PR DESCRIPTION
A `<chip>` read `on_change` but never `on_press`, so a press handler was silently ignored — the chip rendered, animated its selection, and told the server nothing.

### Why it can't just also send a change event

When a press handler exists, selection is **server-driven**: the handler decides what is selected and hands the state back. Toggling locally as well makes the chip fight the value it is given — a filter chip flickers off on its own tap, then snaps back when the server response lands.

So the two paths are exclusive:

- `on_press` set → send the press event only, and leave `isSelected` alone. The server owns it.
- otherwise → the existing local toggle plus `on_change`, unchanged.

Applied to both `NativeUIChipRenderer.swift` and `ChipRenderer.kt` so the platforms agree.

Existing `@change` chips are unaffected — that branch is untouched.