### PR TITLE
fix(android): reserve navigation bar slot for drawer

### DIFF
--- a/resources/android/NativeUIChromeInit.kt
+++ b/resources/android/NativeUIChromeInit.kt
@@ -22,7 +22,11 @@ import com.nativephp.plugins.native_ui.ui.nuiThemeDefaultTypography
  * application context for asset-backed font loading.
  */
 fun registerNativeUIChrome(context: Context) {
-    NativeRootHostRegistry.register("native-ui.drawer", consumes = "native_drawer") { root, content ->
+    NativeRootHostRegistry.register(
+        "native-ui.drawer",
+        consumes = "native_drawer",
+        reservesNavigationBarSlot = true,
+    ) { root, content ->
         val drawerNode = root.children.firstOrNull { it.type == "native_drawer" }
         NativeLayoutDrawerHost(drawerNode = drawerNode, content = content)
     }

--- a/tests/NativeUIChromeInitTest.php
+++ b/tests/NativeUIChromeInitTest.php
@@ -1,0 +1,15 @@
+<?php
+
+test('registers the Android drawer host with navigation bar slot reservation', function () {
+    $source = file_get_contents(dirname(__DIR__).'/resources/android/NativeUIChromeInit.kt');
+    $matched = preg_match(
+        '/NativeRootHostRegistry\.register\(\s*"native-ui\.drawer",(?<arguments>[^)]*)\)/s',
+        $source,
+        $registration,
+    );
+
+    expect($matched)->toBe(1)
+        ->and($registration['arguments'])
+        ->toMatch('/consumes\s*=\s*"native_drawer"/')
+        ->toMatch('/reservesNavigationBarSlot\s*=\s*true/');
+});


### PR DESCRIPTION
## Description

### Summary

Opts the Android drawer root host into the navigation bar slot reservation API introduced by [NativePHP/mobile-air#404](https://github.com/NativePHP/mobile-air/pull/404).

Together, the two changes prevent the drawer button from overlapping the navigation title while preserving the drawer's current overlay implementation.

### Problem

On Android, the `mobile-ui` drawer button is rendered as an overlay at the top-left of the root content. The `mobile-air` `TopAppBar` previously reserved its navigation slot only for a back button, so a root screen with a drawer and no back button placed the navigation title underneath the drawer icon.
<img width="325" height="132" alt="Captura de Tela 2026-08-29 às 15 26 27" src="https://github.com/user-attachments/assets/343fcf86-ee54-45a5-ac57-f6565a87269a" />

iOS already positions the drawer button and title without this overlap.
<img width="330" height="111" alt="Captura de Tela 2026-08-29 às 15 28 55" src="https://github.com/user-attachments/assets/c43980a9-ea7b-47a0-bc67-bc01843b0911" />


### Changes

- Registers the `native-ui.drawer` root host with `reservesNavigationBarSlot = true`.
- Leaves the existing drawer rendering and behavior unchanged.
- Allows the companion `mobile-air` implementation to reserve a `48.dp` navigation slot while the `native_drawer` sentinel is present and no back button is shown.

### Dependency and rollout

This PR depends on [NativePHP/mobile-air#404](https://github.com/NativePHP/mobile-air/pull/404), which adds the `reservesNavigationBarSlot` registration parameter and handles the reserved slot in the stack and tab root renderers.

The changes should be merged and released in this order:

1. `NativePHP/mobile-air#404`.
2. This `mobile-ui` PR.

The updated `mobile-ui` source will not compile against a `mobile-air` version that does not yet provide the new `register()` parameter.

### Testing

The companion `mobile-air` PR includes registry unit coverage and Compose layout tests for both stack and tab root renderers. This PR adds a Pest contract test that verifies the Android drawer registration consumes `native_drawer` and enables `reservesNavigationBarSlot`.

The combined changes should be manually verified on Android with:

- Tab and stack layouts using a drawer.
- Root screens without a back button.
- Nested screens with a back button.
- Navigation bars with and without trailing actions.
- Short and long titles.
- Hidden navigation bars.
- Both `modal` and `reveal` drawer variants.
