### PR TITLE
fix(android): align drawer icon with top app bar

### DIFF
--- a/resources/android/NativeLayoutDrawerHost.kt
+++ b/resources/android/NativeLayoutDrawerHost.kt
@@ -70,7 +70,7 @@ fun NativeLayoutDrawerHost(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .statusBarsPadding()
-                        .padding(start = 4.dp, top = 4.dp)
+                        .padding(start = 4.dp, top = 8.dp)
                 ) {
                     Icon(Icons.Filled.Menu, contentDescription = "Open menu")
                 }


### PR DESCRIPTION
## Description

### Summary

Vertically aligns the Android drawer icon with the top app bar by increasing its top padding from `4.dp` to `8.dp`.

This complements the navigation slot reservation introduced by [NativePHP/mobile-ui#81](https://github.com/NativePHP/mobile-ui/pull/81): that change prevents the navigation title from overlapping the drawer icon, while this change centers the icon within the top app bar.

### Problem

On Android, the drawer icon is rendered as a top-left overlay by `NativeLayoutDrawerHost`. After applying the status bar inset, the existing `4.dp` top padding positions the icon slightly above the top app bar's visual center.

The horizontal position is already correct, but the vertical offset makes the drawer icon appear misaligned relative to the navigation title and trailing actions.

<img width="313" height="107" alt="Captura de Tela 2026-08-29 às 19 31 00" src="https://github.com/user-attachments/assets/39342d0b-55ad-4c21-8e64-cf746c169009" />

### Changes

- Changes the drawer icon's top padding from `4.dp` to `8.dp` on Android.
- Keeps the existing `4.dp` start padding unchanged.
- Leaves drawer state, gestures, rendering, and navigation slot reservation unchanged.
- Does not affect iOS.

<img width="320" height="109" alt="Captura de Tela 2026-08-29 às 20 07 26" src="https://github.com/user-attachments/assets/a026f4e9-dc14-4efe-8751-ceb46430630b" />

### Dependency and rollout

This is a self-contained layout adjustment and introduces no new API or dependency requirements.

It complements [NativePHP/mobile-ui#81](https://github.com/NativePHP/mobile-ui/pull/81) and its companion [NativePHP/mobile-air#404](https://github.com/NativePHP/mobile-air/pull/404), but does not depend on their new registration API and can be reviewed independently.

For end-to-end verification of the complete drawer navigation bar layout, test this change together with those PRs.

### Testing

This change only adjusts a Compose layout constant and has no automated behavioral coverage.

It should be manually verified on Android with:

- Tab and stack layouts using a drawer.
- Root screens without a back button.
- Navigation bars with and without trailing actions.
- Short and long navigation titles.
- Devices or emulators with different status bar insets.
- Both `modal` and `reveal` drawer variants.

Confirm that the drawer icon is vertically centered with the navigation title and trailing actions, remains correctly inset from the status bar, and still opens the drawer normally.
