### PR TITLE
fix(android): inset modal close button below status bar

### DIFF
--- a/resources/android/ModalRenderer.kt
+++ b/resources/android/ModalRenderer.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
@@ -85,7 +86,10 @@ object ModalRenderer {
                 Column(modifier = Modifier.fillMaxSize()) {
                     if (dismissible) {
                         Row(
-                            modifier = Modifier.fillMaxWidth().padding(8.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .statusBarsPadding()
+                                .padding(8.dp),
                             horizontalArrangement = Arrangement.End,
                         ) {
                             IconButton(onClick = {

--- a/tests/ModalRendererTest.php
+++ b/tests/ModalRendererTest.php
@@ -1,0 +1,17 @@
+<?php
+
+test('applies the status bar inset before padding the Android modal close button', function () {
+    $rendererPath = dirname(__DIR__).'/resources/android/ModalRenderer.kt';
+
+    expect($rendererPath)->toBeFile();
+
+    $renderer = file_get_contents($rendererPath);
+    $closeButtonModifierPattern = '/if \(dismissible\) \{\s*Row\(\s*modifier = Modifier\s*'
+        .'\.fillMaxWidth\(\)\s*'
+        .'\.statusBarsPadding\(\)\s*'
+        .'\.padding\(8\.dp\),/s';
+
+    expect($renderer)
+        ->toBeString()
+        ->toMatch($closeButtonModifierPattern);
+});


### PR DESCRIPTION
## Description

### Summary

Keeps the Android modal close button below the status bar by applying the current status bar inset to its header row before the existing `8.dp` content padding.

### Problem

Android modals are rendered as full-screen Compose dialogs with `decorFitsSystemWindows` disabled. When a modal is dismissible, its close-button row previously used only a fixed `8.dp` padding and did not account for the status bar inset.

On edge-to-edge windows, this could place the close button inside the status bar area instead of within the modal's usable content area. The result varies with the device's status bar inset, so the control could appear misplaced or overlap system UI.

<img width="329" height="111" alt="Captura de Tela 2026-08-30 às 10 08 46" src="https://github.com/user-attachments/assets/7aa092f5-10c8-402e-9fa5-0f1ccce9fc9f" />


### Changes

- Adds Compose's `statusBarsPadding()` to the dismissible modal header row on Android.
- Applies the status bar inset before the existing `8.dp` padding, preserving the intended spacing inside the safe content area.
- Adds a Pest regression test that protects the close-button modifier chain and its ordering.
- Leaves modal visibility, dismiss callbacks, back-button handling, outside-tap handling, content rendering, and theming unchanged.
- Does not affect non-dismissible modals or the iOS renderer.

<img width="322" height="102" alt="Captura de Tela 2026-08-30 às 11 26 00" src="https://github.com/user-attachments/assets/a6e67362-ca18-472c-b917-edc5ceebb769" />

### Dependency and rollout

This is a self-contained Android layout fix. It introduces no new public API, configuration, or dependency requirements and can be reviewed and released independently.
