### PR TITLE
Clip Android images with the same per-corner shape containers use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "nativephp/mobile": "^4.0"
+        "nativephp/mobile": "^4.2"
     },
     "autoload": {
         "psr-4": {

--- a/resources/android/ImageRenderer.kt
+++ b/resources/android/ImageRenderer.kt
@@ -1,15 +1,14 @@
 package com.nativephp.plugins.native_ui.ui
 
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.nativephp.mobile.ui.nativerender.NativeUINode
 import com.nativephp.mobile.ui.nativerender.argbToComposeColor
+import com.nativephp.mobile.ui.nativerender.nodeShape
 
 object ImageRenderer {
     @Composable
@@ -21,9 +20,14 @@ object ImageRenderer {
         val tintArgb = p.getColor("tint_color", 0)
         val radius = node.style?.borderRadius ?: 0f
 
-        // Images need explicit clip for rounded corners (nodeStyle doesn't clip globally)
-        val imgModifier = if (radius > 0f) {
-            modifier.clip(RoundedCornerShape(radius.dp))
+        // Images need an explicit clip for rounded corners (nodeStyle doesn't
+        // clip globally). `nodeShape` is the same resolver containers use, so
+        // per-corner radii (`rounded-3xl rounded-br-none`, `rounded-t-2xl`)
+        // clip an image exactly like a column with the same classes. Those
+        // ride the props bag as `radius_tl` etc. with no uniform radius to
+        // fall back on, which is why they count as "has a radius" here.
+        val imgModifier = if (radius > 0f || p.has("radius_tl")) {
+            modifier.clip(nodeShape(radius, p))
         } else modifier
 
         if (src.isNotEmpty()) {


### PR DESCRIPTION
Fixes NativePHP/mobile-air#355.

## Problem

On Android, `<native:image>` clipped with `RoundedCornerShape(style.borderRadius.dp)`, which only knows the uniform radius. Per-corner radii ride the props bag as `radius_tl` / `tr` / `br` / `bl` (PHP resolves each against the uniform value), so:

- `rounded-3xl rounded-br-none` rendered fully rounded instead of squaring off the tail corner.
- `rounded-tl-3xl rounded-tr-3xl` rendered completely square, since there is no uniform radius to fall back on.

A `<native:column>` with the same classes clipped correctly, and iOS honoured both cases on images already.

## Fix

Resolve the clip shape through core's `nodeShape(radius, props)`, the same helper containers use for their background/border shape and `NodeView` uses for press-ripple clipping. A per-corner prop now counts as "has a radius" so the no-uniform case clips too. Images and containers with identical classes now produce identical shapes.

`nodeShape` shipped in nativephp/mobile 4.2.0 (the per-corner radius PR, mobile-air #314), so the `nativephp/mobile` constraint moves from `^4.0` to `^4.2`. Older cores would fail to compile this file otherwise.

## Verification

Demo screen `/masterclass/image-corners` in the kitchen-sink app: each pair is a column (left) and an image (right) with identical classes. Pixel 9 emulator on the left, iPhone 17 simulator on the right. Every image now matches its column, including the bottom-right tail (1), the top-only pair with no uniform radius (2), and the side pair (3).

<img width="1449" height="1600" alt="Image corners demo, Android beside iOS, all pairs matching" src="https://github.com/user-attachments/assets/1c1ae4a0-bfcc-4aa1-b012-509dd4defe97" />

Also compiled against the demo app's Android project (`:app:compileDebugKotlin`) before the device run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpErRGNkHRH7Du6WAzfqBz
