### PR TITLE
Forward min-lines / max-lines to the Android bare text input

### DIFF
--- a/resources/android/BareTextInputRenderer.kt
+++ b/resources/android/BareTextInputRenderer.kt
@@ -145,7 +145,14 @@ object BareTextInputRenderer {
                     else -> theme.primary
                 }
             ),
-            singleLine = !props.multiline,
+            singleLine = props.singleLine,
+            // Line limits were parsed (and defaulted: 5 for multiline) in
+            // parseTextInputProps but never forwarded here, so a multiline
+            // composer grew without bound instead of scrolling internally
+            // at the cap like iOS's lineLimit(min...max). Same forwarding as
+            // the filled/outlined variants.
+            maxLines = props.maxLines,
+            minLines = props.minLines,
             decorationBox = { innerTextField ->
                 if (value.text.isEmpty() && props.placeholder.isNotEmpty()) {
                     Text(


### PR DESCRIPTION
Fixes NativePHP/mobile-air#421.

## Problem

`<bare-text-input multiline :max-lines="5">` grew without limit on Android as the user typed, pushing the rest of the screen away. iOS stops at the cap and scrolls internally.

`parseTextInputProps` in `TextInputShared.kt` already reads `max_lines` and `min_lines` off the node and defaults a multiline field to a five-line cap (the same default iOS's `lineLimit(lower...upper)` applies). The filled and outlined variants pass both to their text fields. `BareTextInputRenderer` only passed `singleLine`, so the parsed values never reached the `BasicTextField`, and even the intended default cap was lost.

## Fix

Forward `maxLines` and `minLines` from the parsed props, using the same `props.singleLine` accessor as the sibling renderers. `BasicTextField` handles the internal scrolling once it has a cap.

Behaviour change to note: a multiline bare input with no explicit `max-lines` now caps at five lines on Android, which is what it already did on iOS and what the shared parser intended.

## Verification

Demo screen `/masterclass/composer-lines` in the kitchen-sink app on the Pixel 9 emulator. Eight lines typed into the `:max-lines="5"` field: it stopped at five lines and scrolled internally (lines 5 to 8 visible with the caret on the sixth row). The `:min-lines="3"` field below it starts three lines tall while empty.

<img width="713" height="1600" alt="Composer line limits demo on Android, field capped at five lines" src="https://github.com/user-attachments/assets/abb5e57e-6556-4849-91ff-697d6d773a8e" />

Also compiled against the demo app's Android project (`:app:compileDebugKotlin`) before the device run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpErRGNkHRH7Du6WAzfqBz
